### PR TITLE
feat(install): interactive setup, start-bg.sh, and docs overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ claude
 | Proxy   | 3180        | `PROXY_PORT` env var |
 | Admin   | 3182        | `ADMIN_PORT` env var |
 
+## Running in the background
+
+`bash start.sh` runs in the foreground — convenient for local dev, but the services will stop when you close the terminal or disconnect SSH. On a server, use `start-bg.sh` instead, which runs `start.sh` inside a detached tmux session:
+
+```bash
+bash start-bg.sh                         # start (returns immediately)
+tmux attach -t claudecode-hub            # see live logs; Ctrl+B then D to detach
+tmux kill-session -t claudecode-hub      # stop
+tmux ls                                  # check whether it's running
+```
+
 ## FAQ
 
 ### Claude Code can't reach the proxy — how do I set `ANTHROPIC_BASE_URL`?

--- a/README.md
+++ b/README.md
@@ -1,34 +1,26 @@
 # claudecode-hub
 
-A self-hosted proxy that lets multiple Claude Code terminals share a pool of Anthropic accounts, with automatic rate-limit-aware routing and a web-based admin dashboard.
+A self-hosted proxy that lets multiple Claude Code terminals share a pool of Anthropic accounts, with automatic rate-limit-aware routing and a web-based admin dashboard. Access is gated by Supabase email auth with role-based permissions (admin manages the account pool; regular users manage their own terminals).
 
 ## Quick Start
 
-**Prerequisites:** Node.js 18+, running on Linux / macOS / WSL
-
-<details>
-<summary>Install Node.js (if not already installed)</summary>
-
-```bash
-# Using nvm (recommended)
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
-source ~/.bashrc
-nvm install --lts
-```
-
-</details>
+**Prerequisites:** Linux / macOS / WSL, a free [Supabase](https://supabase.com/) project. `install.sh` auto-installs the rest on demand (Node.js 22 via nvm, tmux via apt/brew, Claude Code CLI via npm).
 
 ```bash
 git clone https://github.com/Xavier1999-Chen/claudecode-hub.git
 cd claudecode-hub
-bash install.sh
-bash start.sh
+bash install.sh          # interactive — prompts for Supabase URL + anon key, installs deps, builds frontend
 ```
 
-Then open the admin UI at **http://127.0.0.1:3182** and:
+Follow the manual steps `install.sh` prints at the end (Supabase migration + auth URLs + first-admin promotion). Then pick a startup mode:
 
-1. Click **添加账号** to log in with your Anthropic account via OAuth
-2. Go to the **终端** tab and click **新建** to create a terminal — you'll get an API key (`sk-hub-...`)
+- **`bash start.sh`** — runs in the foreground. Good for local dev or quick testing; services stop when the terminal closes.
+- **`bash start-bg.sh`** — runs inside a detached tmux session. Good for servers — survives SSH disconnects. See [Running in the background](#running-in-the-background) for attach/stop commands.
+
+Once logged in as admin:
+
+1. Click **+ 添加账号** (admin-only) → log in with your Anthropic account via OAuth
+2. Go to the **终端** tab, click **+ 新建终端** — you get an API key (`sk-hub-...`)
 3. Point Claude Code at the proxy:
 
 ```bash
@@ -36,6 +28,8 @@ export ANTHROPIC_BASE_URL=http://127.0.0.1:3180
 export ANTHROPIC_API_KEY=sk-hub-...   # the key from step 2
 claude
 ```
+
+**From another machine on the same LAN**, replace `127.0.0.1` with the server's LAN IP (check with `ip addr` or `hostname -I`). For production or multi-user deployments, see the [Advanced — HTTPS with a custom domain](#advanced--https-with-a-custom-domain-caddy) section below.
 
 ## Ports
 
@@ -55,29 +49,58 @@ tmux kill-session -t claudecode-hub      # stop
 tmux ls                                  # check whether it's running
 ```
 
+## Advanced — HTTPS with a custom domain (Caddy)
+
+By default the services serve HTTP. This works but browsers disable several features over plain HTTP (most notably `navigator.clipboard`, so the "复制" buttons in the admin UI silently fail — see FAQ below). HTTPS also protects JWTs and API keys in transit.
+
+The simplest path is [Caddy](https://caddyserver.com/) with automatic Let's Encrypt certificates. This assumes you have a domain pointing at the server (e.g. `hub.example.com`).
+
+**1. DNS** — point two subdomains at your server's public IP:
+- `hub.example.com`     → admin dashboard
+- `api.hub.example.com` → Claude Code proxy
+
+**2. Firewall / security group** — open `80` and `443` (80 is needed for Let's Encrypt's HTTP-01 challenge). You can close public access to `3180` and `3182` now that Caddy fronts them.
+
+**3. Install Caddy** (Debian/Ubuntu):
+
+```bash
+sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https curl
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' \
+  | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' \
+  | sudo tee /etc/apt/sources.list.d/caddy-stable.list
+sudo apt update && sudo apt install -y caddy
+```
+
+**4. Write `/etc/caddy/Caddyfile`** (replace with your domain):
+
+```
+hub.example.com {
+  reverse_proxy localhost:3182
+}
+
+api.hub.example.com {
+  reverse_proxy localhost:3180
+}
+```
+
+Reload: `sudo systemctl reload caddy`. Caddy issues certs on first request (~30s) and auto-renews them.
+
+**5. Update Supabase** — Authentication → URL Configuration:
+- **Site URL**: `https://hub.example.com`
+- **Redirect URLs**: add `https://hub.example.com/**`
+
+**6. Update client config** — Claude Code users now set:
+
+```bash
+export ANTHROPIC_BASE_URL=https://api.hub.example.com
+```
+
+Note: no port — Caddy serves via the standard 443.
+
 ## FAQ
 
-### Claude Code can't reach the proxy — how do I set `ANTHROPIC_BASE_URL`?
-
-**Same machine as the proxy:**
-
-```bash
-export ANTHROPIC_BASE_URL=http://127.0.0.1:3180
-```
-
-**Another machine on the LAN:**
-
-Replace `127.0.0.1` with the proxy server's LAN IP (e.g. `192.168.110.181`):
-
-```bash
-export ANTHROPIC_BASE_URL=http://192.168.110.181:3180
-```
-
-Run `ip addr` or `hostname -I` on the server if you're unsure of its IP.
-
----
-
-### WSL2 + Clash: proxy receives no requests, Claude Code throws `UND_ERR_SOCKET`
+### 1. WSL2 + Clash: proxy receives no requests, Claude Code throws `UND_ERR_SOCKET`
 
 **Symptom:** Claude Code fails with `UND_ERR_SOCKET`, the proxy prints no logs at all, but switching to a different subscription fixes it.
 
@@ -110,13 +133,32 @@ The three ranges above cover all standard private address spaces (RFC 1918). If 
 
 ---
 
+### 2. "复制链接" / "复制 Token" buttons appear to do nothing
+
+**Symptom:** Clicking the copy buttons in the admin dashboard silently fails — nothing lands on the clipboard.
+
+**Cause:** `navigator.clipboard.writeText` only works in a [secure context](https://developer.mozilla.org/docs/Web/Security/Secure_Contexts) — HTTPS, `http://localhost`, or `http://127.0.0.1`. Over plain HTTP on a LAN / public IP (e.g. `http://43.106.26.31:3182`) the API is undefined and the click is a no-op.
+
+**Fix:** put the admin dashboard behind HTTPS. See the [Advanced — HTTPS with a custom domain](#advanced--https-with-a-custom-domain-caddy) section.
+
+---
+
 ## Project structure
 
 ```
 src/
-  proxy/      # API proxy server (forwards requests to Anthropic)
-  admin/      # Admin server + React dashboard
-  shared/     # Config store, name generator
-config/       # Runtime data (gitignored: accounts.json, terminals.json)
-logs/         # Usage logs per account (gitignored)
+  proxy/          # API proxy server (forwards requests to Anthropic)
+  admin/          # Admin server + React dashboard
+    auth.js       # Supabase JWT verification middleware
+  shared/         # Config store, name generator
+supabase/
+  migrations/     # SQL migrations (user_requests table + triggers)
+config/           # Runtime data (gitignored: accounts.json, terminals.json)
+logs/             # Usage logs per account (gitignored)
 ```
+
+## TODO
+
+- [ ] Scheduled backup for `config/` (hourly tar.gz snapshots, 7-day retention). `terminals.json` is painful to restore since every user would need to update their `ANTHROPIC_API_KEY`.
+- [ ] Custom SMTP in Supabase (e.g. [Resend](https://resend.com/)) to escape the free-tier 2-emails-per-hour limit before onboarding real users.
+- [ ] Clean up legacy terminals with no `userId` — they show as "（无主）" for admins; decide whether to claim them or delete.

--- a/install.sh
+++ b/install.sh
@@ -84,6 +84,31 @@ if ! command -v tmux >/dev/null 2>&1; then
 fi
 echo "tmux $(tmux -V | awk '{print $2}') detected"
 
+# ── Claude Code CLI check (auto-install if missing) ──────────────────────────
+# The OAuth login flow in src/admin/oauth-login.js spawns `claude login` inside
+# a tmux session; without the CLI, users can't add Anthropic accounts.
+if ! command -v claude >/dev/null 2>&1; then
+  echo ""
+  echo "Claude Code CLI (the \`claude\` command) is required to add Anthropic accounts"
+  echo "through the OAuth flow. Install it globally via npm now?"
+  echo "This will run: npm install -g @anthropic-ai/claude-code"
+  if confirm_default_yes ""; then
+    npm install -g @anthropic-ai/claude-code
+    if ! command -v claude >/dev/null 2>&1; then
+      echo ""
+      echo "Error: claude CLI install did not complete successfully."
+      echo "Try manually: npm install -g @anthropic-ai/claude-code"
+      exit 1
+    fi
+  else
+    echo ""
+    echo "Manual install:"
+    echo "  npm install -g @anthropic-ai/claude-code"
+    exit 1
+  fi
+fi
+echo "Claude Code CLI $(claude --version 2>/dev/null | head -1 || echo 'detected')"
+
 # ── Supabase environment setup ───────────────────────────────────────────────
 # Admin server requires SUPABASE_URL + SUPABASE_ANON_KEY to verify JWTs.
 # Frontend requires VITE_SUPABASE_URL + VITE_SUPABASE_ANON_KEY for auth.

--- a/install.sh
+++ b/install.sh
@@ -2,14 +2,135 @@
 set -e
 cd "$(dirname "$0")"
 
-# ── Check Node.js ────────────────────────────────────────────────────────────
-NODE_MAJOR=$(node -e 'process.stdout.write(process.versions.node.split(".")[0])' 2>/dev/null || echo "0")
-if [ "$NODE_MAJOR" -lt 18 ]; then
-  echo "Error: Node.js 18 or higher is required (found: $(node --version 2>/dev/null || echo 'not installed'))"
-  exit 1
-fi
+# Ask yes/no with default Y. Returns 0 (yes) or 1 (no).
+confirm_default_yes() {
+  local prompt="$1"
+  local ans
+  read -r -p "$prompt [Y/n]: " ans
+  case "$ans" in
+    n|N|no|NO) return 1 ;;
+    *) return 0 ;;
+  esac
+}
 
+# ── Node.js check (auto-install via nvm if missing/old) ──────────────────────
+node_major() {
+  node -e 'process.stdout.write(process.versions.node.split(".")[0])' 2>/dev/null || echo "0"
+}
+
+NODE_MAJOR=$(node_major)
+if [ "$NODE_MAJOR" -lt 22 ]; then
+  FOUND=$(node --version 2>/dev/null || echo "not installed")
+  echo ""
+  echo "Node.js 22+ is required (found: $FOUND)."
+  echo "Install Node 22 via nvm now? This will:"
+  echo "  - Install nvm to ~/.nvm (downloads install.sh from nvm-sh/nvm)"
+  echo "  - Install and switch to Node 22"
+  if confirm_default_yes ""; then
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+    export NVM_DIR="$HOME/.nvm"
+    # shellcheck disable=SC1091
+    [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+    nvm install 22
+    nvm use 22
+    NODE_MAJOR=$(node_major)
+    if [ "$NODE_MAJOR" -lt 22 ]; then
+      echo ""
+      echo "Error: Node 22 installation did not complete successfully."
+      echo "Install manually: https://nodejs.org/  or  nvm install 22"
+      exit 1
+    fi
+  else
+    echo ""
+    echo "Manual install:"
+    echo "  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash"
+    echo "  source ~/.bashrc"
+    echo "  nvm install 22 && nvm use 22"
+    exit 1
+  fi
+fi
 echo "Node.js $(node --version) detected"
+
+# ── tmux check (auto-install if missing) ─────────────────────────────────────
+if ! command -v tmux >/dev/null 2>&1; then
+  echo ""
+  echo "tmux is required (used by the OAuth login flow for adding Anthropic accounts)."
+  INSTALL_CMD=""
+  if command -v apt-get >/dev/null 2>&1; then
+    INSTALL_CMD="sudo apt-get update && sudo apt-get install -y tmux"
+  elif command -v brew >/dev/null 2>&1; then
+    INSTALL_CMD="brew install tmux"
+  else
+    echo "Error: no supported package manager found (apt-get or brew)."
+    echo "Install tmux manually from your distro's package repository."
+    exit 1
+  fi
+  echo "Install tmux now? This will run:"
+  echo "  $INSTALL_CMD"
+  echo "(sudo may prompt for your password)"
+  if confirm_default_yes ""; then
+    eval "$INSTALL_CMD"
+    if ! command -v tmux >/dev/null 2>&1; then
+      echo ""
+      echo "Error: tmux install did not complete successfully."
+      exit 1
+    fi
+  else
+    echo "Manual install:"
+    echo "  $INSTALL_CMD"
+    exit 1
+  fi
+fi
+echo "tmux $(tmux -V | awk '{print $2}') detected"
+
+# ── Supabase environment setup ───────────────────────────────────────────────
+# Admin server requires SUPABASE_URL + SUPABASE_ANON_KEY to verify JWTs.
+# Frontend requires VITE_SUPABASE_URL + VITE_SUPABASE_ANON_KEY for auth.
+if [ -f .env ] && grep -q '^SUPABASE_URL=' .env && grep -q '^SUPABASE_ANON_KEY=' .env; then
+  echo "Supabase config found in .env — reusing."
+else
+  cat <<'INFO'
+
+────── Supabase setup ──────
+This project uses Supabase for user login/registration.
+
+  1. Create a free project:  https://supabase.com/dashboard
+  2. Open the API settings:  https://supabase.com/dashboard/project/_/settings/api
+     (Supabase will redirect `_` to your actual project.)
+  3. Copy these two values and paste them below:
+     - Project URL           (e.g.  https://xxxxxxxxxxxxxxxx.supabase.co)
+     - anon public key       (e.g.  sb_publishable_xxxxx...)
+
+INFO
+  read -r -p "SUPABASE_URL: " SB_URL
+  read -r -p "SUPABASE_ANON_KEY: " SB_KEY
+
+  if [ -z "$SB_URL" ]; then
+    echo ""
+    echo "Error: SUPABASE_URL is empty."
+    echo "Re-run 'bash install.sh' and paste the Project URL from"
+    echo "  https://supabase.com/dashboard/project/_/settings/api"
+    exit 1
+  fi
+  if [ -z "$SB_KEY" ]; then
+    echo ""
+    echo "Error: SUPABASE_ANON_KEY is empty."
+    echo "Re-run 'bash install.sh' and paste the anon public key from"
+    echo "  https://supabase.com/dashboard/project/_/settings/api"
+    exit 1
+  fi
+
+  cat > .env <<EOF
+SUPABASE_URL=$SB_URL
+SUPABASE_ANON_KEY=$SB_KEY
+EOF
+  cat > src/admin/frontend/.env.local <<EOF
+VITE_MOCK=false
+VITE_SUPABASE_URL=$SB_URL
+VITE_SUPABASE_ANON_KEY=$SB_KEY
+EOF
+  echo ".env and src/admin/frontend/.env.local written."
+fi
 
 # ── Install root dependencies ────────────────────────────────────────────────
 echo ""
@@ -28,10 +149,31 @@ cd ../../..
 mkdir -p config
 
 # ── Done ─────────────────────────────────────────────────────────────────────
-echo ""
-echo "Installation complete."
-echo ""
-echo "Next steps:"
-echo "  1. Run: bash start.sh"
-echo "  2. Open admin UI: http://127.0.0.1:3182"
-echo "  3. Add a Claude account via the admin UI to get started"
+cat <<'DONE'
+
+Installation complete.
+
+Remaining manual steps (all in the Supabase Dashboard):
+
+  1. Apply the migration — SQL Editor:
+       https://supabase.com/dashboard/project/_/sql/new
+     Paste the contents of supabase/migrations/20260420000000_user_approval.sql and Run.
+
+  2. Configure auth URLs — Authentication → URL Configuration:
+       https://supabase.com/dashboard/project/_/auth/url-configuration
+     - Site URL:        http://<your-host>:3182
+     - Redirect URLs:   http://<your-host>:3182/**
+                        http://localhost:3182/**
+
+  3. Start the services:
+       bash start.sh
+
+  4. Register at http://<your-host>:3182, verify email, then promote yourself
+     to admin via SQL Editor:
+       UPDATE public.user_requests
+       SET status='approved', role='admin'
+       WHERE email='you@example.com';
+
+  5. Sign out and sign back in to pick up the admin JWT.
+
+DONE

--- a/install.sh
+++ b/install.sh
@@ -33,6 +33,7 @@ if [ "$NODE_MAJOR" -lt 22 ]; then
     [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
     nvm install 22
     nvm use 22
+    nvm alias default 22
     NODE_MAJOR=$(node_major)
     if [ "$NODE_MAJOR" -lt 22 ]; then
       echo ""

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -348,7 +348,7 @@ function sanitiseAccount(acc) {
 }
 
 async function aggregateUsage(range, group) {
-  const projectRoot = fileURLToPath(new URL('../../..', import.meta.url));
+  const projectRoot = fileURLToPath(new URL('../..', import.meta.url));
   const logsDir = join(projectRoot, 'logs');
 
   const now = Date.now();

--- a/src/proxy/usage-tracker.js
+++ b/src/proxy/usage-tracker.js
@@ -3,7 +3,7 @@ import { mkdir, appendFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const projectRoot = fileURLToPath(new URL('../../..', import.meta.url));
+const projectRoot = fileURLToPath(new URL('../..', import.meta.url));
 const DEFAULT_LOGS_DIR = join(projectRoot, 'logs');
 
 // Rough USD cost per million tokens (input/output) by model prefix

--- a/start-bg.sh
+++ b/start-bg.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Run start.sh inside a detached tmux session so the services survive SSH
+# disconnects. Use this on servers; use start.sh directly for local dev / CI.
+
+set -e
+cd "$(dirname "$0")"
+
+SESSION="claudecode-hub"
+
+if ! command -v tmux >/dev/null 2>&1; then
+  echo "Error: tmux is not installed. Run 'bash install.sh' first."
+  exit 1
+fi
+
+if tmux has-session -t "$SESSION" 2>/dev/null; then
+  echo "tmux session '$SESSION' is already running."
+  echo "  Attach (see logs):   tmux attach -t $SESSION"
+  echo "  Stop:                tmux kill-session -t $SESSION"
+  exit 0
+fi
+
+tmux new-session -d -s "$SESSION" 'bash start.sh'
+
+# Give start.sh a moment to fail fast (e.g. preflight .env check)
+sleep 1
+
+if ! tmux has-session -t "$SESSION" 2>/dev/null; then
+  echo "Error: start.sh exited immediately. Run 'bash start.sh' directly to see the error."
+  exit 1
+fi
+
+cat <<INFO
+Started in tmux session '$SESSION'.
+
+  Attach (see logs):        tmux attach -t $SESSION
+  Detach while running:     press Ctrl+B, then D
+  Stop:                     tmux kill-session -t $SESSION
+  Status:                   tmux ls
+INFO

--- a/start.sh
+++ b/start.sh
@@ -1,9 +1,23 @@
 #!/bin/bash
 cd "$(dirname "$0")"
 
+# Load nvm if present, so `node` is on PATH even if the shell hasn't sourced
+# ~/.bashrc since install.sh finished.
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+# shellcheck disable=SC1091
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+
 # Preflight: install.sh is responsible for writing .env with Supabase config.
 if [ ! -f .env ] || ! grep -q '^SUPABASE_URL=' .env || ! grep -q '^SUPABASE_ANON_KEY=' .env; then
   echo "Error: .env is missing or incomplete. Run 'bash install.sh' first."
+  exit 1
+fi
+
+# Preflight: node must be on PATH.
+if ! command -v node >/dev/null 2>&1; then
+  echo "Error: 'node' not found on PATH."
+  echo "If you just finished 'bash install.sh', open a new shell or run:"
+  echo "  source ~/.bashrc && bash start.sh"
   exit 1
 fi
 

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 cd "$(dirname "$0")"
 
+# Preflight: install.sh is responsible for writing .env with Supabase config.
+if [ ! -f .env ] || ! grep -q '^SUPABASE_URL=' .env || ! grep -q '^SUPABASE_ANON_KEY=' .env; then
+  echo "Error: .env is missing or incomplete. Run 'bash install.sh' first."
+  exit 1
+fi
+
 node --env-file-if-exists=.env src/proxy/index.js &
 PROXY=$!
 


### PR DESCRIPTION
## Summary

- **`install.sh`**: interactive prerequisite setup (Node 22, tmux, Claude CLI, Supabase keys) with auto-install prompts; writes `.env` and `src/admin/frontend/.env.local`
- **`start.sh`**: preflight check — refuses to start if `.env` is missing or lacks Supabase keys
- **`start-bg.sh`** (new): tmux wrapper for detached background operation; idempotent (won't start duplicate sessions)
- **`fix(logs)`**: correct `projectRoot` path in `usage-tracker.js` (`../../..` → `../..`); logs were being written one directory too high
- **`docs`**: README overhaul — Supabase auth, Caddy HTTPS section, `start-bg.sh` usage, clipboard-over-HTTP FAQ, updated TODO

## Test plan

- [x] Fresh clone: `bash install.sh` prompts for missing prerequisites and Supabase keys
- [x] Re-run `bash install.sh` on existing setup: skips Supabase prompt (idempotent)
- [x] `bash start.sh` without `.env`: exits with clear error message
- [x] `bash start-bg.sh`: starts services in tmux session `claudecode-hub`; re-run prints attach/stop hints
- [x] Usage logs appear under `<project-root>/logs/` (not one level above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)