### PR TITLE
fix(oauth-login): forward HTTPS_PROXY to tmux claude login session

### DIFF
--- a/src/admin/oauth-login.js
+++ b/src/admin/oauth-login.js
@@ -28,7 +28,14 @@ export async function startTmuxLogin() {
 
   // Launch claude login in detached tmux session (80-col window)
   const claudePath = (await execAsync('which claude').catch(() => ({ stdout: 'claude' }))).stdout.trim();
-  const cmd = `tmux new-session -d -x 200 -y 50 -s ${tmuxSession} -e CLAUDE_CONFIG_DIR=${configDir} '${claudePath} login'`;
+  // Forward outbound-proxy env vars so `claude login` can reach api.anthropic.com
+  // on servers where direct egress is blocked (e.g. HK → Anthropic via a Singapore relay).
+  // tmux sessions don't inherit these from the parent shell unless passed with -e.
+  const proxyEnv = [];
+  for (const key of ['HTTPS_PROXY', 'https_proxy', 'HTTP_PROXY', 'http_proxy', 'NO_PROXY', 'no_proxy']) {
+    if (process.env[key]) proxyEnv.push(`-e ${key}=${process.env[key]}`);
+  }
+  const cmd = `tmux new-session -d -x 200 -y 50 -s ${tmuxSession} -e CLAUDE_CONFIG_DIR=${configDir} ${proxyEnv.join(' ')} '${claudePath} login'`;
   await execAsync(cmd);
 
   // Step 1: wait for theme prompt, then press Enter to accept default

--- a/src/admin/oauth-login.js
+++ b/src/admin/oauth-login.js
@@ -14,8 +14,30 @@ const proxyUrl = process.env.HTTPS_PROXY || process.env.https_proxy
                || process.env.HTTP_PROXY  || process.env.http_proxy;
 const proxyAgent = proxyUrl ? new HttpsProxyAgent(proxyUrl) : undefined;
 
+const PROXY_ENV_KEYS = ['HTTPS_PROXY', 'https_proxy', 'HTTP_PROXY', 'http_proxy', 'NO_PROXY', 'no_proxy'];
+
+/**
+ * Build argv for `tmux new-session`. Pure function; argv form bypasses /bin/sh,
+ * so proxy env values containing shell metacharacters are passed through intact.
+ */
+export function buildTmuxNewSessionArgs({ tmuxSession, configDir, claudePath, env = {} }) {
+  const args = [
+    'new-session', '-d',
+    '-x', '200', '-y', '50',
+    '-s', tmuxSession,
+    '-e', `CLAUDE_CONFIG_DIR=${configDir}`,
+  ];
+  for (const key of PROXY_ENV_KEYS) {
+    if (env[key]) args.push('-e', `${key}=${env[key]}`);
+  }
+  args.push(`${claudePath} login`);
+  return args;
+}
+
 /**
  * Start `claude login` in a detached tmux session with an isolated CLAUDE_CONFIG_DIR.
+ * Forwards HTTPS_PROXY / HTTP_PROXY / NO_PROXY (and lowercase variants) from process.env
+ * via tmux `-e`, so the child can reach api.anthropic.com behind an outbound proxy.
  * Handles two interactive prompts (theme + login method), then captures the authorization URL.
  * Returns { sessionId, configDir, tmuxSession, authUrl }
  */
@@ -26,17 +48,11 @@ export async function startTmuxLogin() {
 
   await mkdir(configDir, { recursive: true });
 
-  // Launch claude login in detached tmux session (80-col window)
   const claudePath = (await execAsync('which claude').catch(() => ({ stdout: 'claude' }))).stdout.trim();
-  // Forward outbound-proxy env vars so `claude login` can reach api.anthropic.com
-  // on servers where direct egress is blocked (e.g. HK → Anthropic via a Singapore relay).
-  // tmux sessions don't inherit these from the parent shell unless passed with -e.
-  const proxyEnv = [];
-  for (const key of ['HTTPS_PROXY', 'https_proxy', 'HTTP_PROXY', 'http_proxy', 'NO_PROXY', 'no_proxy']) {
-    if (process.env[key]) proxyEnv.push(`-e ${key}=${process.env[key]}`);
-  }
-  const cmd = `tmux new-session -d -x 200 -y 50 -s ${tmuxSession} -e CLAUDE_CONFIG_DIR=${configDir} ${proxyEnv.join(' ')} '${claudePath} login'`;
-  await execAsync(cmd);
+  // Use execFile (argv form) to avoid /bin/sh interpreting proxy values that may
+  // contain $, spaces, `;`, backticks, etc. — same rationale as submitAuthCode below.
+  const args = buildTmuxNewSessionArgs({ tmuxSession, configDir, claudePath, env: process.env });
+  await execFileAsync('tmux', args);
 
   // Step 1: wait for theme prompt, then press Enter to accept default
   await waitForText(tmuxSession, 'Choose the text style', 10000);

--- a/tests/oauth-login.test.js
+++ b/tests/oauth-login.test.js
@@ -1,0 +1,81 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { buildTmuxNewSessionArgs } from '../src/admin/oauth-login.js';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+const baseOpts = {
+  tmuxSession: 'hub-test',
+  configDir: '/tmp/hub-acc-test',
+  claudePath: '/usr/bin/claude',
+};
+
+function indexOfPair(args, flag, value) {
+  for (let i = 0; i < args.length - 1; i++) {
+    if (args[i] === flag && args[i + 1] === value) return i;
+  }
+  return -1;
+}
+
+test('buildTmuxNewSessionArgs: baseline args include session, config dir, and login command', () => {
+  const args = buildTmuxNewSessionArgs({ ...baseOpts, env: {} });
+
+  assert.ok(indexOfPair(args, '-s', 'hub-test') !== -1, 'must include "-s hub-test" as adjacent elements');
+  assert.ok(
+    indexOfPair(args, '-e', 'CLAUDE_CONFIG_DIR=/tmp/hub-acc-test') !== -1,
+    'must include "-e CLAUDE_CONFIG_DIR=..." as adjacent elements',
+  );
+  assert.equal(args[args.length - 1], '/usr/bin/claude login', 'last arg must be the claude login command');
+  assert.equal(args[0], 'new-session');
+});
+
+test('buildTmuxNewSessionArgs: forwards all six proxy env keys as separate argv elements', () => {
+  const env = {
+    HTTPS_PROXY: 'http://p:8080',
+    https_proxy: 'http://p:8080',
+    HTTP_PROXY: 'http://p:8081',
+    http_proxy: 'http://p:8081',
+    NO_PROXY: 'localhost,127.0.0.1',
+    no_proxy: 'localhost,127.0.0.1',
+  };
+  const args = buildTmuxNewSessionArgs({ ...baseOpts, env });
+
+  for (const [key, value] of Object.entries(env)) {
+    assert.ok(
+      indexOfPair(args, '-e', `${key}=${value}`) !== -1,
+      `must pass "-e ${key}=${value}" as two adjacent argv elements (not a merged shell string)`,
+    );
+  }
+});
+
+test('buildTmuxNewSessionArgs: omits proxy -e flags for unset keys', () => {
+  const args = buildTmuxNewSessionArgs({ ...baseOpts, env: {} });
+  const hasProxyFlag = args.some(a => /^(HTTPS?|NO)_PROXY=|^(https?|no)_proxy=/.test(a));
+  assert.equal(hasProxyFlag, false, 'no proxy -e flag should be emitted when env is empty');
+});
+
+test('buildTmuxNewSessionArgs: preserves shell metacharacters verbatim (no shell interpretation)', () => {
+  // A proxy URL containing chars that /bin/sh would interpret: $, space, ;, backtick, quote
+  const malicious = 'http://user:p$word with space;rm -rf /@proxy:8080';
+  const args = buildTmuxNewSessionArgs({
+    ...baseOpts,
+    env: { HTTPS_PROXY: malicious },
+  });
+
+  // The value must appear as one intact argv element — not split on spaces, no $ expansion.
+  assert.ok(
+    indexOfPair(args, '-e', `HTTPS_PROXY=${malicious}`) !== -1,
+    'malicious proxy value must survive as a single argv element, proving argv-form bypasses the shell',
+  );
+});
+
+test('startTmuxLogin JSDoc mentions proxy env forwarding', async () => {
+  const src = await readFile(join(repoRoot, 'src/admin/oauth-login.js'), 'utf8');
+  const match = src.match(/\/\*\*([\s\S]*?)\*\/\s*export\s+async\s+function\s+startTmuxLogin/);
+  assert.ok(match, 'expected JSDoc block immediately before startTmuxLogin');
+  assert.match(match[1], /proxy/i, 'JSDoc should document the proxy env forwarding side effect');
+});


### PR DESCRIPTION
## Summary

When the admin server runs behind an outbound HTTP proxy (e.g. HK server routing Anthropic traffic via a Singapore relay through mihomo), the \`claude login\` tmux session couldn't reach \`api.anthropic.com\` and failed with \`ERR_BAD_REQUEST\`, producing a blank authorization URL in the Add Account modal.

Root cause: \`tmux new-session\` does NOT inherit env vars from the parent shell — they must be passed explicitly with \`-e\`. The code passed \`-e CLAUDE_CONFIG_DIR\` but not \`HTTPS_PROXY\`, so claude CLI attempted direct egress and was blocked.

Fix: forward \`HTTPS_PROXY\` / \`HTTP_PROXY\` / \`NO_PROXY\` (and lowercase variants) to the tmux session alongside \`CLAUDE_CONFIG_DIR\`.

## Test plan

- [x] Reproduced on HK ECS: \`claude login\` in tmux without proxy env returned \`Unable to connect to Anthropic services\`
- [x] Verified that adding \`-e HTTPS_PROXY=...\` makes the same command show the welcome wizard (connects successfully)
- [ ] After merge + restart, Add Account flow in admin UI returns a valid authorization URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)