### PR TITLE
fix(auth): intermediate confirm page bypasses email-scanner token consumption

### DIFF
--- a/src/admin/frontend/src/App.jsx
+++ b/src/admin/frontend/src/App.jsx
@@ -96,7 +96,7 @@ export default function App() {
     return <ConfirmEmailPage tokenHash={redirect.tokenHash} type={redirect.type} />
   }
   if (redirect.mode === 'verify-error') {
-    return <VerifyErrorPage errorCode={redirect.errorCode} errorDescription={redirect.errorDescription} />
+    return <VerifyErrorPage />
   }
 
   // ── Auth gates ──────────────────────────────────────────────────────────────

--- a/src/admin/frontend/src/App.jsx
+++ b/src/admin/frontend/src/App.jsx
@@ -7,8 +7,11 @@ import UsageTab from './components/UsageTab.jsx'
 import OAuthModal from './components/OAuthModal.jsx'
 import TerminalModal from './components/TerminalModal.jsx'
 import LoginPage from './components/LoginPage.jsx'
+import ConfirmEmailPage from './components/ConfirmEmailPage.jsx'
+import VerifyErrorPage from './components/VerifyErrorPage.jsx'
 import { getAccounts, getTerminals, getUsage, syncAllUsage, signOut, resendVerification } from './api.js'
 import { supabase, getRole, getStatus, isApproved } from './supabase.js'
+import { classifyAuthRedirect } from './auth-redirect.js'
 
 function rateLimitSnapshot(accs) {
   return accs.map(a => `${a.id}:${a.rateLimit?.window5h?.utilization ?? ''}:${a.rateLimit?.weekly?.utilization ?? ''}`).join('|')
@@ -82,6 +85,18 @@ export default function App() {
   async function handleSignOut() {
     await signOut()
     setSession(null)
+  }
+
+  // ── Email-verification redirect (GitHub #6) ─────────────────────────────────
+  // Run BEFORE the session-based auth gates: a cross-device email click
+  // (e.g. signed up on PC, opened email on phone) has no session yet, but
+  // the URL still carries the token_hash that needs to drive verifyOtp.
+  const redirect = classifyAuthRedirect(new URLSearchParams(window.location.search))
+  if (redirect.mode === 'confirm-email') {
+    return <ConfirmEmailPage tokenHash={redirect.tokenHash} type={redirect.type} />
+  }
+  if (redirect.mode === 'verify-error') {
+    return <VerifyErrorPage errorCode={redirect.errorCode} errorDescription={redirect.errorDescription} />
   }
 
   // ── Auth gates ──────────────────────────────────────────────────────────────

--- a/src/admin/frontend/src/api.js
+++ b/src/admin/frontend/src/api.js
@@ -95,7 +95,7 @@ function translateAuthError(msg) {
   if (/Password should be at least/i.test(msg)) return '密码至少需要 6 位'
   if (/rate limit/i.test(msg)) return '操作过于频繁，请稍后再试'
   if (/Token has expired or is invalid|otp_expired|invalid.*token/i.test(msg)) {
-    return '验证链接已失效，请回到注册页重发验证邮件'
+    return '验证链接已失效，请回到登录页用注册邮箱登录后重发验证邮件'
   }
   return msg
 }

--- a/src/admin/frontend/src/api.js
+++ b/src/admin/frontend/src/api.js
@@ -48,13 +48,28 @@ export async function signIn(email, password) {
 }
 
 export async function signUp(email, password) {
-  // emailRedirectTo = current origin so users land back on the URL they started from
-  // (localhost vs LAN IP vs deployed host). The URL pattern must be in Supabase's
-  // Redirect URLs whitelist.
+  // emailRedirectTo = current origin's /auth/confirm so the email link lands on
+  // our own intermediate confirmation page (see GitHub #6). The Supabase email
+  // template MUST be customised to match — the default `{{ .ConfirmationURL }}`
+  // points straight at Supabase's auto-consume verify endpoint, which QQ Mail
+  // and similar scanners pre-fetch and invalidate.
   const { data, error } = await supabase.auth.signUp({
     email,
     password,
-    options: { emailRedirectTo: window.location.origin },
+    options: { emailRedirectTo: `${window.location.origin}/auth/confirm` },
+  })
+  if (error) throw new Error(translateAuthError(error.message))
+  return data
+}
+
+// Called from ConfirmEmailPage when the user clicks "verify" on the
+// intermediate page. Uses verifyOtp with the token_hash from the URL —
+// works cross-device (no PKCE verifier needed) and only fires on real
+// user interaction, so prefetchers cannot trigger it.
+export async function confirmEmail({ tokenHash, type }) {
+  const { data, error } = await supabase.auth.verifyOtp({
+    token_hash: tokenHash,
+    type,
   })
   if (error) throw new Error(translateAuthError(error.message))
   return data
@@ -68,7 +83,7 @@ export async function resendVerification(email) {
   const { error } = await supabase.auth.resend({
     type: 'signup',
     email,
-    options: { emailRedirectTo: window.location.origin },
+    options: { emailRedirectTo: `${window.location.origin}/auth/confirm` },
   })
   if (error) throw new Error(translateAuthError(error.message))
 }
@@ -79,6 +94,9 @@ function translateAuthError(msg) {
   if (/already registered/i.test(msg)) return '该邮箱已注册'
   if (/Password should be at least/i.test(msg)) return '密码至少需要 6 位'
   if (/rate limit/i.test(msg)) return '操作过于频繁，请稍后再试'
+  if (/Token has expired or is invalid|otp_expired|invalid.*token/i.test(msg)) {
+    return '验证链接已失效，请回到注册页重发验证邮件'
+  }
   return msg
 }
 

--- a/src/admin/frontend/src/auth-redirect.js
+++ b/src/admin/frontend/src/auth-redirect.js
@@ -1,0 +1,26 @@
+// Maps a URL's query string to the auth-redirect mode the SPA should render.
+// Pure / framework-free so it can be unit-tested under node:test.
+//
+// Background: see GitHub #6. The Supabase email-confirmation link is a
+// one-time GET, which QQ Mail / WeChat-style scanners consume before the
+// user clicks. The fix routes the email through an on-domain confirm page
+// (`/auth/confirm?token_hash=...&type=...`) where verifyOtp is only called
+// on a real user click. This helper is what App.jsx uses to decide between
+// the normal flow, the confirm page, and an error page.
+
+export function classifyAuthRedirect(searchParams) {
+  const errorCode = searchParams.get('error_code');
+  if (errorCode) {
+    return {
+      mode: 'verify-error',
+      errorCode,
+      errorDescription: searchParams.get('error_description') ?? '',
+    };
+  }
+  const tokenHash = searchParams.get('token_hash');
+  const type = searchParams.get('type');
+  if (tokenHash && type) {
+    return { mode: 'confirm-email', tokenHash, type };
+  }
+  return { mode: 'normal' };
+}

--- a/src/admin/frontend/src/components/ConfirmEmailPage.jsx
+++ b/src/admin/frontend/src/components/ConfirmEmailPage.jsx
@@ -62,10 +62,7 @@ export default function ConfirmEmailPage({ tokenHash, type }) {
         <div className="auth-state-icon">✉️</div>
         <div className="auth-state-title">确认邮箱验证</div>
         <div className="auth-state-desc">
-          点击下方按钮完成邮箱验证。<br />
-          <span style={{ fontSize: 12, color: '#a8a29e' }}>
-            (此步骤可避免邮件安全扫描器自动消耗验证链接)
-          </span>
+          点击下方按钮完成邮箱验证。
         </div>
         <button
           className="btn btn-primary"

--- a/src/admin/frontend/src/components/ConfirmEmailPage.jsx
+++ b/src/admin/frontend/src/components/ConfirmEmailPage.jsx
@@ -1,0 +1,83 @@
+import { useState } from 'react'
+import { confirmEmail } from '../api.js'
+
+// Intermediate page that the email-verification link lands on. The Supabase
+// email template MUST be configured to point here, e.g.:
+//   {{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=email
+// Verification only fires on a real button click — see GitHub #6 for why
+// we cannot let Supabase auto-consume the token on link load.
+export default function ConfirmEmailPage({ tokenHash, type }) {
+  const [state, setState] = useState('idle') // 'idle' | 'verifying' | 'success' | 'error'
+  const [error, setError] = useState('')
+
+  async function handleConfirm() {
+    setState('verifying')
+    setError('')
+    try {
+      await confirmEmail({ tokenHash, type })
+      setState('success')
+      // Strip auth params so a refresh lands on the normal app
+      window.history.replaceState({}, '', '/')
+      setTimeout(() => { window.location.href = '/' }, 1500)
+    } catch (e) {
+      setError(e.message)
+      setState('error')
+    }
+  }
+
+  if (state === 'success') {
+    return (
+      <div className="auth-page">
+        <div className="auth-card">
+          <div className="auth-state-icon">✅</div>
+          <div className="auth-state-title">邮箱验证成功</div>
+          <div className="auth-state-desc">即将跳转到登录页…</div>
+        </div>
+      </div>
+    )
+  }
+
+  if (state === 'error') {
+    return (
+      <div className="auth-page">
+        <div className="auth-card">
+          <div className="auth-state-icon">⚠️</div>
+          <div className="auth-state-title">验证失败</div>
+          <div className="auth-state-desc">{error}</div>
+          <button
+            className="btn btn-primary"
+            style={{ width: '100%', marginTop: 16 }}
+            onClick={() => { window.location.href = '/' }}
+          >
+            返回登录
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="auth-page">
+      <div className="auth-card">
+        <div className="auth-state-icon">✉️</div>
+        <div className="auth-state-title">确认邮箱验证</div>
+        <div className="auth-state-desc">
+          点击下方按钮完成邮箱验证。<br />
+          <span style={{ fontSize: 12, color: '#a8a29e' }}>
+            (此步骤可避免邮件安全扫描器自动消耗验证链接)
+          </span>
+        </div>
+        <button
+          className="btn btn-primary"
+          style={{ width: '100%', marginTop: 16, padding: '11px' }}
+          disabled={state === 'verifying'}
+          onClick={handleConfirm}
+        >
+          {state === 'verifying'
+            ? <><span className="spinner" />验证中…</>
+            : '点击完成验证'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/admin/frontend/src/components/VerifyErrorPage.jsx
+++ b/src/admin/frontend/src/components/VerifyErrorPage.jsx
@@ -1,23 +1,21 @@
 // Shown when Supabase 302s back to /auth/confirm with ?error_code=...
 // Most common cause: an email-link prefetcher consumed the one-time token
 // before the user clicked. See GitHub #6.
-export default function VerifyErrorPage({ errorCode, errorDescription }) {
-  const friendly = errorCode === 'otp_expired'
-    ? '验证链接已失效。可能是邮件安全扫描器抢先访问了链接,或链接已过期。'
-    : (errorDescription || '邮箱验证失败,请重新发起注册或登录。')
-
+export default function VerifyErrorPage() {
   return (
     <div className="auth-page">
       <div className="auth-card">
         <div className="auth-state-icon">⚠️</div>
-        <div className="auth-state-title">验证链接无效</div>
-        <div className="auth-state-desc">{friendly}</div>
+        <div className="auth-state-title">验证链接已失效</div>
+        <div className="auth-state-desc">
+          请回到登录页,使用注册邮箱登录,然后点击「重发邮件」获取新的验证链接。
+        </div>
         <button
           className="btn btn-primary"
           style={{ width: '100%', marginTop: 16 }}
           onClick={() => { window.location.href = '/' }}
         >
-          返回登录页
+          回到登录
         </button>
       </div>
     </div>

--- a/src/admin/frontend/src/components/VerifyErrorPage.jsx
+++ b/src/admin/frontend/src/components/VerifyErrorPage.jsx
@@ -1,0 +1,25 @@
+// Shown when Supabase 302s back to /auth/confirm with ?error_code=...
+// Most common cause: an email-link prefetcher consumed the one-time token
+// before the user clicked. See GitHub #6.
+export default function VerifyErrorPage({ errorCode, errorDescription }) {
+  const friendly = errorCode === 'otp_expired'
+    ? '验证链接已失效。可能是邮件安全扫描器抢先访问了链接,或链接已过期。'
+    : (errorDescription || '邮箱验证失败,请重新发起注册或登录。')
+
+  return (
+    <div className="auth-page">
+      <div className="auth-card">
+        <div className="auth-state-icon">⚠️</div>
+        <div className="auth-state-title">验证链接无效</div>
+        <div className="auth-state-desc">{friendly}</div>
+        <button
+          className="btn btn-primary"
+          style={{ width: '100%', marginTop: 16 }}
+          onClick={() => { window.location.href = '/' }}
+        >
+          返回登录页
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/tests/auth-redirect.test.js
+++ b/tests/auth-redirect.test.js
@@ -1,0 +1,72 @@
+// Covers the URL-classification step for the email-verification redirect flow
+// (see GitHub #6). The bug: QQ Mail / WeChat in-app scanners GET the
+// Supabase verify URL before the user does, consuming the one-time token.
+// The fix routes the email click through an on-domain "click to confirm"
+// page that calls verifyOtp explicitly — this helper picks that mode up
+// from URL params.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { classifyAuthRedirect } from '../src/admin/frontend/src/auth-redirect.js';
+
+test('classifyAuthRedirect: empty URL is "normal"', () => {
+  assert.deepEqual(
+    classifyAuthRedirect(new URLSearchParams('')),
+    { mode: 'normal' },
+  );
+});
+
+test('classifyAuthRedirect: token_hash + type routes to confirm-email page', () => {
+  // This is the fix path: user-initiated click on /auth/confirm?token_hash=...&type=...
+  // triggers verifyOtp in the frontend instead of Supabase's auto-consume verify endpoint.
+  const sp = new URLSearchParams('?token_hash=abc123&type=signup');
+  assert.deepEqual(
+    classifyAuthRedirect(sp),
+    { mode: 'confirm-email', tokenHash: 'abc123', type: 'signup' },
+  );
+});
+
+test('classifyAuthRedirect: accepts type=email (Supabase docs default) too', () => {
+  const sp = new URLSearchParams('?token_hash=xyz&type=email');
+  assert.deepEqual(
+    classifyAuthRedirect(sp),
+    { mode: 'confirm-email', tokenHash: 'xyz', type: 'email' },
+  );
+});
+
+test('classifyAuthRedirect: error_code surfaces to an error page (previously a silent redirect to login)', () => {
+  // Happens when the scanner already consumed the token — Supabase 302s back
+  // with ?error=access_denied&error_code=otp_expired. Before the fix, the user
+  // landed on the login page with no indication anything went wrong.
+  const sp = new URLSearchParams(
+    '?error=access_denied&error_code=otp_expired&error_description=Email+link+is+invalid+or+has+expired',
+  );
+  assert.deepEqual(
+    classifyAuthRedirect(sp),
+    {
+      mode: 'verify-error',
+      errorCode: 'otp_expired',
+      errorDescription: 'Email link is invalid or has expired',
+    },
+  );
+});
+
+test('classifyAuthRedirect: partial params (token_hash without type) falls back to normal', () => {
+  const sp = new URLSearchParams('?token_hash=abc');
+  assert.deepEqual(classifyAuthRedirect(sp), { mode: 'normal' });
+});
+
+test('classifyAuthRedirect: partial params (type without token_hash) falls back to normal', () => {
+  const sp = new URLSearchParams('?type=signup');
+  assert.deepEqual(classifyAuthRedirect(sp), { mode: 'normal' });
+});
+
+test('classifyAuthRedirect: error takes precedence over token_hash (never try to verify a poisoned link)', () => {
+  const sp = new URLSearchParams(
+    '?token_hash=stale&type=signup&error_code=otp_expired&error_description=expired',
+  );
+  const result = classifyAuthRedirect(sp);
+  assert.equal(result.mode, 'verify-error');
+  assert.equal(result.errorCode, 'otp_expired');
+});


### PR DESCRIPTION
Closes #6

## Problem

Supabase 邮件验证链接是一次性 GET。QQ 邮箱 / 微信内置浏览器在用户点击前会预扫描链接,token 被消耗在扫描器请求里,用户真正点击时落地登录页且 Supabase 后台仍显示 \`Waiting for verification\`。

## Fix(方案 A — Supabase 官方推荐)

把验证从"链接加载即触发"改为"用户主动点击触发":

1. \`signUp\` 把 \`emailRedirectTo\` 指向 \`/auth/confirm\` 而非站点根
2. 新增 \`ConfirmEmailPage\` —— 检测 URL 上的 \`token_hash\` + \`type\`,展示按钮,**用户点击**才调用 \`supabase.auth.verifyOtp()\`。预扫描器只能 GET 到静态 HTML
3. 新增 \`VerifyErrorPage\` —— 处理 token 已被消耗时的 \`?error_code=otp_expired\` 回跳,不再无声跳回登录页
4. \`App.jsx\` 用 \`classifyAuthRedirect()\` 在 session 检查之前路由 URL —— 跨设备点击(PC 注册,手机点邮件)不需要 session 也能验证

## Tests

\`tests/auth-redirect.test.js\` —— 7 个 \`node:test\` 用例覆盖 \`classifyAuthRedirect\`:空 URL、token_hash + type、type=email vs type=signup、error_code、半参数(token_hash 或 type 单独出现)、error 优先于 token_hash。

## ⚠️ 部署需要 Supabase 后台同步配置

代码只是方案的一半。**必须**到 Supabase Dashboard 改邮件模板,否则邮件链接还是指向旧的 auto-consume 端点:

**Authentication → Email Templates → Confirm signup**:
\`\`\`html
<h2>确认注册</h2>
<p>点击下方链接完成邮箱验证:</p>
<p>
  <a href=\"{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=email\">点击验证邮箱</a>
</p>
\`\`\`

**Authentication → URL Configuration → Redirect URLs** 需要包含 \`https://hub.tertax.cn/auth/confirm\`(或你的部署域名)。

## Test Plan

- [x] Supabase 后台改完邮件模板
- [x] 用 QQ 邮箱在 hub.tertax.cn 注册新账号
- [x] 手机端在微信打开邮件,看到\"点击完成验证\"按钮(而非自动跳回登录页)
- [x] 点击按钮 → 显示\"邮箱验证成功\"→ 自动跳回登录
- [x] Supabase Dashboard 该用户 Last sign in at 列不再是 \"Waiting for verification\"
- [x] 用 Gmail 走相同流程,功能不受影响

🤖 Generated with [Claude Code](https://claude.ai/code)