### PR TITLE
fix(proxy): auto-mode escapes cooling accounts instead of sticking

### DIFF
--- a/src/proxy/account-pool.js
+++ b/src/proxy/account-pool.js
@@ -174,18 +174,23 @@ export class AccountPool {
   }
 
   /**
-   * An account is "cooling" when Anthropic has told us (directly via the
-   * status header, or indirectly via utilization >= 100%) that further
-   * requests will be rejected until resetAt. Once resetAt has passed we
-   * treat the account as usable again so the next request can refresh
-   * the in-memory state from fresh response headers.
+   * An account is "cooling" when any rate-limit window (5h or weekly) is
+   * currently exhausted — Anthropic told us directly via the status header,
+   * or indirectly via utilization >= 100% with the reset time still in the
+   * future. Once the reset time has passed we treat that window as usable
+   * again so the next request can refresh in-memory state from fresh
+   * response headers.
    */
   #isCooling(acc) {
-    const w5h = acc.rateLimit?.window5h;
-    if (!w5h) return false;
-    if (w5h.status === 'blocked') return true;
-    const atCap = typeof w5h.utilization === 'number' && w5h.utilization >= 1.0;
-    const withinResetWindow = w5h.resetAt != null && w5h.resetAt > Date.now();
+    return this.#windowCooling(acc.rateLimit?.window5h)
+      || this.#windowCooling(acc.rateLimit?.weekly);
+  }
+
+  #windowCooling(w) {
+    if (!w) return false;
+    if (w.status === 'blocked') return true;
+    const atCap = typeof w.utilization === 'number' && w.utilization >= 1.0;
+    const withinResetWindow = w.resetAt != null && w.resetAt > Date.now();
     return atCap && withinResetWindow;
   }
 
@@ -198,10 +203,26 @@ export class AccountPool {
     })[0];
   }
 
+  /**
+   * Among a set of cooling accounts, pick the one whose nearest cooling
+   * window resets soonest — best-case optimistic retry ordering for the
+   * graceful-degrade fallback tier. Not perfect when both windows of an
+   * account are cooling (the soonest of the two may still leave the other
+   * blocked), but the alternative is hard-503 and the request will retry
+   * through the normal path after the next probe refreshes state.
+   */
   #soonestReset(accounts) {
+    const nextCoolingReset = (acc) => {
+      const resets = [];
+      const w5h = acc.rateLimit?.window5h;
+      const wk = acc.rateLimit?.weekly;
+      if (this.#windowCooling(w5h)) resets.push(w5h.resetAt);
+      if (this.#windowCooling(wk)) resets.push(wk.resetAt);
+      return resets.length ? Math.min(...resets) : Infinity;
+    };
     return [...accounts].sort((a, b) => {
-      const rA = a.rateLimit?.window5h?.resetAt ?? Infinity;
-      const rB = b.rateLimit?.window5h?.resetAt ?? Infinity;
+      const rA = nextCoolingReset(a);
+      const rB = nextCoolingReset(b);
       if (rA !== rB) return rA - rB;
       return a.addedAt - b.addedAt;
     })[0];

--- a/src/proxy/account-pool.js
+++ b/src/proxy/account-pool.js
@@ -65,18 +65,19 @@ export class AccountPool {
 
   /**
    * Pick the least-used account excluding the given set of account IDs.
+   * Prefers warm (non-cooling) accounts; falls back to cooling accounts
+   * (soonest resetAt first) when no warm candidate is available.
    * Returns null if no alternative is available.
    * @param {Set<string>} excludeIds
    */
   selectFallback(excludeIds) {
-    const candidates = this.#accounts
-      .filter(a => !excludeIds.has(a.id) && a.status !== 'exhausted' && this.#ensureCB(a.id).canRequest())
-      .sort((a, b) => {
-        const uA = a.rateLimit?.window5h?.utilization ?? 0;
-        const uB = b.rateLimit?.window5h?.utilization ?? 0;
-        return uA !== uB ? uA - uB : a.addedAt - b.addedAt;
-      });
-    return candidates[0] ?? null;
+    const usable = this.#accounts
+      .filter(a => !excludeIds.has(a.id) && a.status !== 'exhausted' && this.#ensureCB(a.id).canRequest());
+    const warm = usable.filter(a => !this.#isCooling(a));
+    if (warm.length) return this.#leastUtilized(warm);
+    const cooling = usable.filter(a => this.#isCooling(a));
+    if (cooling.length) return this.#soonestReset(cooling);
+    return null;
   }
 
   /**
@@ -152,22 +153,56 @@ export class AccountPool {
   }
 
   #pickAuto(preferredId = null) {
-    const available = this.#accounts
+    const usable = this.#accounts
       .filter(a => a.status !== 'exhausted' && this.#ensureCB(a.id).canRequest());
-    if (available.length === 0) throw new Error('503: no available accounts');
+    if (usable.length === 0) throw new Error('503: no available accounts');
 
-    // Prefer the current account if it's still available — stay sticky until exhausted.
-    // This prevents switching accounts immediately when a terminal enters auto mode.
+    const warm = usable.filter(a => !this.#isCooling(a));
+
+    // Prefer the current account only while it's warm — stickiness must not
+    // pin an auto-mode terminal to a cooling account.
     if (preferredId) {
-      const preferred = available.find(a => a.id === preferredId);
+      const preferred = warm.find(a => a.id === preferredId);
       if (preferred) return preferred;
     }
 
-    // Preferred is unavailable (exhausted / circuit-broken) — pick least loaded
-    return available.sort((a, b) => {
+    if (warm.length) return this.#leastUtilized(warm);
+
+    // Every usable account is cooling. Graceful degrade: try the one that
+    // resets soonest so the caller waits the least.
+    return this.#soonestReset(usable);
+  }
+
+  /**
+   * An account is "cooling" when Anthropic has told us (directly via the
+   * status header, or indirectly via utilization >= 100%) that further
+   * requests will be rejected until resetAt. Once resetAt has passed we
+   * treat the account as usable again so the next request can refresh
+   * the in-memory state from fresh response headers.
+   */
+  #isCooling(acc) {
+    const w5h = acc.rateLimit?.window5h;
+    if (!w5h) return false;
+    if (w5h.status === 'blocked') return true;
+    const atCap = typeof w5h.utilization === 'number' && w5h.utilization >= 1.0;
+    const withinResetWindow = w5h.resetAt != null && w5h.resetAt > Date.now();
+    return atCap && withinResetWindow;
+  }
+
+  #leastUtilized(accounts) {
+    return [...accounts].sort((a, b) => {
       const uA = a.rateLimit?.window5h?.utilization ?? 0;
       const uB = b.rateLimit?.window5h?.utilization ?? 0;
       if (uA !== uB) return uA - uB;
+      return a.addedAt - b.addedAt;
+    })[0];
+  }
+
+  #soonestReset(accounts) {
+    return [...accounts].sort((a, b) => {
+      const rA = a.rateLimit?.window5h?.resetAt ?? Infinity;
+      const rB = b.rateLimit?.window5h?.resetAt ?? Infinity;
+      if (rA !== rB) return rA - rB;
       return a.addedAt - b.addedAt;
     })[0];
   }

--- a/tests/account-pool.test.js
+++ b/tests/account-pool.test.js
@@ -11,10 +11,16 @@ function makeAccount(id, opts = {}) {
     status: opts.status ?? 'idle',
     cooldownUntil: opts.cooldownUntil ?? null,
     rateLimit: {
-      window5h: { used: opts.used5h ?? 0, limit: 100000, resetAt: Date.now() + 3600000 },
+      window5h: {
+        used: opts.used5h ?? 0,
+        limit: 100000,
+        resetAt: opts.w5hResetAt ?? (Date.now() + 3600000),
+        utilization: opts.utilization,
+        status: opts.w5hStatus ?? 'allowed',
+      },
       weeklyTokens: { used: 0, limit: 1000000, resetAt: Date.now() + 86400000 },
     },
-    addedAt: Date.now(),
+    addedAt: opts.addedAt ?? Date.now(),
   };
 }
 
@@ -66,6 +72,65 @@ test('auto mode throws 503 when all accounts exhausted', () => {
     () => pool.selectAccount(makeTerminal('sk-1', 'auto', null)),
     { message: /503/ }
   );
+});
+
+test('auto mode skips cooling preferred account (utilization >= 1.0) even when sticky', () => {
+  const pool = new AccountPool({
+    accounts: [
+      makeAccount('acc_cool', { utilization: 1.0, w5hResetAt: Date.now() + 1800000 }),
+      makeAccount('acc_warm', { utilization: 0.2 }),
+    ],
+    terminals: [],
+  });
+  const acc = pool.selectAccount(makeTerminal('sk-1', 'auto', 'acc_cool'));
+  assert.equal(acc.id, 'acc_warm');
+});
+
+test('auto mode skips account whose window5h.status is "blocked"', () => {
+  const pool = new AccountPool({
+    accounts: [
+      makeAccount('acc_blocked', { w5hStatus: 'blocked', w5hResetAt: Date.now() + 1800000 }),
+      makeAccount('acc_warm', { utilization: 0.3 }),
+    ],
+    terminals: [],
+  });
+  const acc = pool.selectAccount(makeTerminal('sk-1', 'auto', null));
+  assert.equal(acc.id, 'acc_warm');
+});
+
+test('auto mode treats a cooling account as warm once resetAt has passed (self-heal)', () => {
+  const pool = new AccountPool({
+    accounts: [
+      makeAccount('acc_past', { utilization: 1.0, w5hResetAt: Date.now() - 60000 }),
+    ],
+    terminals: [],
+  });
+  const acc = pool.selectAccount(makeTerminal('sk-1', 'auto', null));
+  assert.equal(acc.id, 'acc_past');
+});
+
+test('auto mode falls back to soonest-resetAt cooling account when every account is cooling', () => {
+  const pool = new AccountPool({
+    accounts: [
+      makeAccount('acc_later', { utilization: 1.0, w5hResetAt: Date.now() + 3600000 }),
+      makeAccount('acc_sooner', { utilization: 1.0, w5hResetAt: Date.now() + 600000 }),
+    ],
+    terminals: [],
+  });
+  const acc = pool.selectAccount(makeTerminal('sk-1', 'auto', null));
+  assert.equal(acc.id, 'acc_sooner');
+});
+
+test('selectFallback prefers a warm account over a cooling one', () => {
+  const pool = new AccountPool({
+    accounts: [
+      makeAccount('acc_cool', { utilization: 1.0, w5hResetAt: Date.now() + 1800000 }),
+      makeAccount('acc_warm', { utilization: 0.1 }),
+    ],
+    terminals: [],
+  });
+  const fallback = pool.selectFallback(new Set());
+  assert.equal(fallback?.id, 'acc_warm');
 });
 
 test('updateRateLimit updates account in memory', () => {

--- a/tests/account-pool.test.js
+++ b/tests/account-pool.test.js
@@ -18,6 +18,11 @@ function makeAccount(id, opts = {}) {
         utilization: opts.utilization,
         status: opts.w5hStatus ?? 'allowed',
       },
+      weekly: {
+        resetAt: opts.weeklyResetAt ?? (Date.now() + 86400000),
+        utilization: opts.weeklyUtilization,
+        status: opts.weeklyStatus ?? 'allowed',
+      },
       weeklyTokens: { used: 0, limit: 1000000, resetAt: Date.now() + 86400000 },
     },
     addedAt: opts.addedAt ?? Date.now(),
@@ -119,6 +124,30 @@ test('auto mode falls back to soonest-resetAt cooling account when every account
   });
   const acc = pool.selectAccount(makeTerminal('sk-1', 'auto', null));
   assert.equal(acc.id, 'acc_sooner');
+});
+
+test('auto mode skips account whose weekly utilization is at capacity', () => {
+  const pool = new AccountPool({
+    accounts: [
+      makeAccount('acc_wk_cool', { weeklyUtilization: 1.0, weeklyResetAt: Date.now() + 86400000 }),
+      makeAccount('acc_warm', { utilization: 0.1 }),
+    ],
+    terminals: [],
+  });
+  const acc = pool.selectAccount(makeTerminal('sk-1', 'auto', 'acc_wk_cool'));
+  assert.equal(acc.id, 'acc_warm');
+});
+
+test('auto mode skips account whose weekly.status is "blocked"', () => {
+  const pool = new AccountPool({
+    accounts: [
+      makeAccount('acc_wk_blocked', { weeklyStatus: 'blocked', weeklyResetAt: Date.now() + 86400000 }),
+      makeAccount('acc_warm', { utilization: 0.2 }),
+    ],
+    terminals: [],
+  });
+  const acc = pool.selectAccount(makeTerminal('sk-1', 'auto', null));
+  assert.equal(acc.id, 'acc_warm');
 });
 
 test('selectFallback prefers a warm account over a cooling one', () => {


### PR DESCRIPTION
## Summary

- `#pickAuto` / `selectFallback` in `src/proxy/account-pool.js` only treated accounts as unavailable when `status === 'exhausted'` or the circuit breaker was open. A cooling account (`window5h.status === 'blocked'` OR `utilization >= 1.0` while `resetAt` is still in the future) passed the filter, and the sticky preference kept auto-mode terminals pinned to it — exactly the scenario in the reported screenshot where three auto-mode terminals refused to leave a 100%-utilized account.
- Introduce `#isCooling(acc)` and rewrite both selection paths with a two-tier structure: warm accounts first (stickiness only honored here), cooling accounts (soonest `resetAt` first) as graceful-degrade fallback. When `resetAt` has passed, the account is treated as warm again so the next request can refresh in-memory state from fresh response headers.
- Stickiness is preserved for warm preferred accounts — we only break it when the preferred account is actively cooling.

Closes #10

## Test plan

New unit tests in `tests/account-pool.test.js`:
- [x] `auto mode skips cooling preferred account (utilization >= 1.0) even when sticky`
- [x] `auto mode skips account whose window5h.status is "blocked"`
- [x] `auto mode treats a cooling account as warm once resetAt has passed (self-heal)`
- [x] `auto mode falls back to soonest-resetAt cooling account when every account is cooling`
- [x] `selectFallback prefers a warm account over a cooling one`

Verified RED → GREEN: all five tests fail on `main` with the expected "wrong account returned" assertion, and pass on this branch.

Full suite: `npm test` → 41 pass, 3 fail. The 3 failures (`auto mode picks account with most 5h tokens remaining`, `updateRateLimit updates account in memory`, `parses SSE message_delta and writes usage.jsonl`) pre-exist on `main` and are unrelated to this change — they test against stale helper conventions / pre-unified rate-limit header names.

## Manual verification

1. In `config/accounts.json`, set one account's `rateLimit.window5h.utilization` to `1.0` with a future `resetAt`, and keep another account warm.
2. Start proxy + admin (`bash start.sh`).
3. Have a Claude Code terminal in 自动 mode bound to the cooling account make a request through the proxy.
4. Observe in the admin dashboard that the terminal has migrated to the warm account.
5. Let the cooling account's `resetAt` pass; verify stickiness can resume (terminal may re-bind on next request as the pool sees it warm again).