### PR TITLE
fix(frontend): isRateLimited mirrors the backend rule and also catches weekly exhaustion

### DIFF
--- a/src/admin/frontend/src/components/AccountsTab.jsx
+++ b/src/admin/frontend/src/components/AccountsTab.jsx
@@ -117,8 +117,12 @@ export default function AccountsTab({ accounts, terminals, onRefresh, onNewTermi
   }
 
   function isRateLimited(acc) {
-    const w5h = acc.rateLimit?.window5h
-    return w5h?.status === 'blocked' || (w5h?.utilization != null && w5h.utilization >= 1.0)
+    return isWindowRateLimited(acc.rateLimit?.window5h) || isWindowRateLimited(acc.rateLimit?.weekly)
+  }
+
+  function isWindowRateLimited(w) {
+    if (!w) return false
+    return w.status === 'blocked' || (w.utilization != null && w.utilization >= 1.0)
   }
 
   function statusDot(acc) {


### PR DESCRIPTION
## Summary

- \`isRateLimited(acc)\` in \`AccountsTab.jsx\` only checked \`window5h\`, so cards for accounts at 100%+ weekly quota still rendered green and stayed mountable even though any real request would 429. The screenshot on #15 has two such accounts visible.
- Extract \`isWindowRateLimited(w)\` and have \`isRateLimited\` return true if EITHER \`window5h\` or \`weekly\` is blocked / at capacity. Mirrors the backend rule in PR #11's amended \`#isCooling\`, so the two layers agree on what "cooling" means.

Closes #15

## Test plan

Frontend has no unit-test harness; verified via:

- [x] \`npm run lint\` introduces no new warnings/errors.
- [ ] Manual: the two weekly-exhausted accounts from the screenshot (\`Uhazlittoswald46Hg50\` at 101% 本周, \`uWcharlessalome73e054\` at 100% 本周) now show the red status dot and the \`⏸ 冷却中\` badge.
- [ ] Manual: clicking a weekly-cooling account while a terminal is selected no longer mounts — the \`mountAccount\` early-out on \`isRateLimited\` now catches it.
- [ ] Manual: accounts whose only cooling signal is weekly \`status === 'blocked'\` are treated the same as ones at \`weekly.utilization >= 1.0\`.

## Related

Paired with PR #11's most recent commit which extended the backend \`#isCooling\` to both windows. Both PRs can be merged independently; they don't share files.