### PR TITLE
feat(admin): syncRateLimit 时主动迁移冷却账号的 auto 终端

### DIFF
--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -9,6 +9,7 @@ import { isExpired, refreshToken } from '../proxy/token-manager.js';
 import { generateName } from '../shared/names.js';
 import { createLoginSession, importCredentials, startTmuxLogin, submitAuthCode, waitForCredentials } from './oauth-login.js';
 import { requireAuth, requireApproved, requireAdmin } from './auth.js';
+import { isAccountCooling, reassignCoolingTerminals } from './reassignment.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PORT = process.env.ADMIN_PORT ?? 3182;
@@ -67,6 +68,9 @@ app.post('/api/accounts/:id/sync-usage', requireAdmin, async (req, res) => {
   try {
     await syncRateLimit(acc);
     await configStore.writeAccounts(accounts);
+    if (isAccountCooling(acc)) {
+      await reassignCoolingTerminals(acc.id, accounts, ['auto'], configStore);
+    }
     res.json(sanitiseAccount(acc));
   } catch (err) {
     res.status(502).json({ error: err.message });
@@ -419,6 +423,11 @@ app.post('/api/sync-usage-all', requireAdmin, async (_req, res) => {
     const accounts = await configStore.readAccounts();
     for (const acc of accounts) await syncRateLimit(acc);
     await configStore.writeAccounts(accounts);
+    for (const acc of accounts) {
+      if (isAccountCooling(acc)) {
+        await reassignCoolingTerminals(acc.id, accounts, ['auto'], configStore);
+      }
+    }
     res.json(accounts.map(sanitiseAccount));
   } catch (err) {
     res.status(500).json({ error: err.message });

--- a/src/admin/reassignment.js
+++ b/src/admin/reassignment.js
@@ -1,0 +1,59 @@
+/**
+ * Server-side mirror of the proxy's cooling detection + terminal
+ * reassignment helpers. Used by admin sync-usage endpoints to
+ * proactively move auto-mode terminals off accounts that have just
+ * entered cooldown, without waiting for the next request to trigger
+ * a 429 + fallback on the proxy side.
+ */
+
+export function isWindowCooling(w) {
+  if (!w) return false;
+  if (w.status === 'blocked') return true;
+  const atCap = typeof w.utilization === 'number' && w.utilization >= 1.0;
+  const withinResetWindow = w.resetAt != null && w.resetAt > Date.now();
+  return atCap && withinResetWindow;
+}
+
+export function isAccountCooling(acc) {
+  return isWindowCooling(acc?.rateLimit?.window5h)
+    || isWindowCooling(acc?.rateLimit?.weekly);
+}
+
+/**
+ * Move terminals off a cooling account onto the warmest alternative.
+ *
+ * @param {string} coolingAccountId — the account that entered cooldown
+ * @param {object[]} accounts — full account list (incl. the cooling one)
+ * @param {string[] | null} modes — ['auto'] to touch only auto-mode terminals, null for all
+ * @param {{ readTerminals: () => Promise<object[]>, writeTerminals: (t: object[]) => Promise<void> }} configStore_
+ *
+ * No-op when:
+ *   - no terminals match the account + modes filter
+ *   - no warm (non-cooling, non-exhausted) alternative exists
+ *     — keeping terminals where they are is better than piling them onto
+ *     the same "least bad" cooling account; the proxy's fallback tier
+ *     handles routing until something frees up.
+ */
+export async function reassignCoolingTerminals(coolingAccountId, accounts, modes, configStore_) {
+  const terminals = await configStore_.readTerminals();
+  const affected = terminals.filter(t =>
+    t.accountId === coolingAccountId
+    && (modes === null || modes.includes(t.mode))
+  );
+  if (!affected.length) return;
+
+  const others = accounts.filter(a =>
+    a.id !== coolingAccountId && a.status !== 'exhausted'
+  );
+  const warm = others.filter(a => !isAccountCooling(a));
+  if (!warm.length) return;
+
+  const best = warm.slice().sort((a, b) => {
+    const uA = a.rateLimit?.window5h?.utilization ?? 0;
+    const uB = b.rateLimit?.window5h?.utilization ?? 0;
+    return uA - uB;
+  })[0];
+
+  for (const t of affected) t.accountId = best.id;
+  await configStore_.writeTerminals(terminals);
+}

--- a/tests/admin-reassignment.test.js
+++ b/tests/admin-reassignment.test.js
@@ -1,0 +1,143 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  isWindowCooling,
+  isAccountCooling,
+  reassignCoolingTerminals,
+} from '../src/admin/reassignment.js';
+
+function makeAccount(id, opts = {}) {
+  return {
+    id,
+    status: opts.status ?? 'idle',
+    rateLimit: {
+      window5h: {
+        utilization: opts.utilization,
+        status: opts.w5hStatus ?? 'allowed',
+        resetAt: opts.w5hResetAt ?? (Date.now() + 3600000),
+      },
+      weekly: {
+        utilization: opts.weeklyUtilization,
+        status: opts.weeklyStatus ?? 'allowed',
+        resetAt: opts.weeklyResetAt ?? (Date.now() + 86400000),
+      },
+    },
+  };
+}
+
+function makeTerminal(id, mode, accountId) {
+  return { id, name: id, mode, accountId };
+}
+
+function makeStore(terminals) {
+  const state = { terminals: [...terminals] };
+  return {
+    state,
+    readTerminals: async () => state.terminals.map(t => ({ ...t })),
+    writeTerminals: async (ts) => { state.terminals = ts.map(t => ({ ...t })); },
+  };
+}
+
+test('isWindowCooling: status "blocked" is cooling', () => {
+  assert.equal(isWindowCooling({ status: 'blocked', resetAt: Date.now() + 1000 }), true);
+});
+
+test('isWindowCooling: utilization >= 1.0 with future resetAt is cooling', () => {
+  assert.equal(isWindowCooling({ utilization: 1.0, resetAt: Date.now() + 1000 }), true);
+  assert.equal(isWindowCooling({ utilization: 1.5, resetAt: Date.now() + 1000 }), true);
+});
+
+test('isWindowCooling: utilization >= 1.0 with past resetAt is NOT cooling (self-heal)', () => {
+  assert.equal(isWindowCooling({ utilization: 1.0, resetAt: Date.now() - 1000 }), false);
+});
+
+test('isWindowCooling: utilization < 1.0 is not cooling', () => {
+  assert.equal(isWindowCooling({ utilization: 0.5, resetAt: Date.now() + 1000 }), false);
+});
+
+test('isWindowCooling: null/undefined window is not cooling', () => {
+  assert.equal(isWindowCooling(null), false);
+  assert.equal(isWindowCooling(undefined), false);
+});
+
+test('isAccountCooling: window5h cooling triggers account-level cooling', () => {
+  const acc = makeAccount('a', { utilization: 1.0 });
+  assert.equal(isAccountCooling(acc), true);
+});
+
+test('isAccountCooling: weekly cooling triggers account-level cooling', () => {
+  const acc = makeAccount('a', { weeklyUtilization: 1.0 });
+  assert.equal(isAccountCooling(acc), true);
+});
+
+test('isAccountCooling: neither cooling returns false', () => {
+  const acc = makeAccount('a', { utilization: 0.2, weeklyUtilization: 0.3 });
+  assert.equal(isAccountCooling(acc), false);
+});
+
+test('reassignCoolingTerminals: moves auto terminals to the warmest account', async () => {
+  const accounts = [
+    makeAccount('acc_cool', { utilization: 1.0 }),
+    makeAccount('acc_low', { utilization: 0.1 }),
+    makeAccount('acc_high', { utilization: 0.6 }),
+  ];
+  const store = makeStore([
+    makeTerminal('t1', 'auto', 'acc_cool'),
+    makeTerminal('t2', 'auto', 'acc_cool'),
+  ]);
+  await reassignCoolingTerminals('acc_cool', accounts, ['auto'], store);
+  assert.equal(store.state.terminals[0].accountId, 'acc_low');
+  assert.equal(store.state.terminals[1].accountId, 'acc_low');
+});
+
+test('reassignCoolingTerminals: leaves manual-mode terminals untouched', async () => {
+  const accounts = [
+    makeAccount('acc_cool', { utilization: 1.0 }),
+    makeAccount('acc_warm', { utilization: 0.1 }),
+  ];
+  const store = makeStore([
+    makeTerminal('t_manual', 'manual', 'acc_cool'),
+    makeTerminal('t_auto',   'auto',   'acc_cool'),
+  ]);
+  await reassignCoolingTerminals('acc_cool', accounts, ['auto'], store);
+  assert.equal(store.state.terminals.find(t => t.id === 't_manual').accountId, 'acc_cool');
+  assert.equal(store.state.terminals.find(t => t.id === 't_auto').accountId,   'acc_warm');
+});
+
+test('reassignCoolingTerminals: leaves terminals in place when no warm account exists', async () => {
+  const accounts = [
+    makeAccount('acc_cool_a', { utilization: 1.0 }),
+    makeAccount('acc_cool_b', { utilization: 1.0 }),
+  ];
+  const store = makeStore([
+    makeTerminal('t_auto', 'auto', 'acc_cool_a'),
+  ]);
+  await reassignCoolingTerminals('acc_cool_a', accounts, ['auto'], store);
+  assert.equal(store.state.terminals[0].accountId, 'acc_cool_a');
+});
+
+test('reassignCoolingTerminals: excludes exhausted accounts from candidates', async () => {
+  const accounts = [
+    makeAccount('acc_cool',   { utilization: 1.0 }),
+    makeAccount('acc_dead',   { utilization: 0.1, status: 'exhausted' }),
+    makeAccount('acc_warm',   { utilization: 0.3 }),
+  ];
+  const store = makeStore([
+    makeTerminal('t_auto', 'auto', 'acc_cool'),
+  ]);
+  await reassignCoolingTerminals('acc_cool', accounts, ['auto'], store);
+  assert.equal(store.state.terminals[0].accountId, 'acc_warm');
+});
+
+test('reassignCoolingTerminals: no-op when no affected terminals', async () => {
+  const accounts = [
+    makeAccount('acc_cool', { utilization: 1.0 }),
+    makeAccount('acc_warm', { utilization: 0.1 }),
+  ];
+  const store = makeStore([
+    makeTerminal('t_auto', 'auto', 'acc_warm'), // not on the cooling account
+  ]);
+  const before = store.state.terminals[0].accountId;
+  await reassignCoolingTerminals('acc_cool', accounts, ['auto'], store);
+  assert.equal(store.state.terminals[0].accountId, before);
+});


### PR DESCRIPTION
## 概要

PR #11 改善了 proxy 的路由层（请求不会打到冷却账号），但它只在「请求到达时」做选择，不改 \`terminals.json\`。UI 里看到的终端绑定依然是冷却账号，视觉上没"迁移"。

本 PR 在服务端补上缺失的那一步：**在 \`syncRateLimit\` 之后**，如果账号现在冷却中（\`window5h\` 或 \`weekly\` 任一 status=='blocked' 或 utilization>=1.0 且 resetAt 未过），调用迁移逻辑把该账号上的 auto 模式终端挪到最低利用率的热账号上。无热账号就不迁移，避免所有终端堆到同一个"least bad"的冷却账号上。

- 新模块 \`src/admin/reassignment.js\`：独立可测试的 \`isWindowCooling\`、\`isAccountCooling\`、\`reassignCoolingTerminals\`。
- \`src/admin/index.js\` 的 \`/api/accounts/:id/sync-usage\` 和 \`/api/sync-usage-all\` 两处 hook：写盘后自动调用迁移。
- manual 模式终端完全不动；\`exhausted\` 账号不做候选。
- 写回 \`terminals.json\` 由 configStore.writeTerminals 原子替换，proxy 的 fs.watch + 5s 轮询自动 reload。

Closes #17

## 测试计划

新建 \`tests/admin-reassignment.test.js\` 共 13 个用例：
- [x] \`isWindowCooling\`: status blocked / utilization ≥ 1.0 且 resetAt 未过 / resetAt 已过（自愈）/ utilization < 1.0 / null window
- [x] \`isAccountCooling\`: window5h 饱和 / weekly 饱和 / 两者都不冷却
- [x] \`reassignCoolingTerminals\`: 迁到最低利用率账号 / 跳过 manual / 没有热账号时不迁 / 排除 exhausted / 无匹配终端时 no-op

RED → GREEN: 写测试前模块不存在，\`node --test\` 报 ERR_MODULE_NOT_FOUND；实现后 13/13 全绿。全量 \`npm test\`：49 pass / 3 fail（3 个失败是 main 上已有的 pre-existing，与本 PR 无关）。

## 手动验证（ECS 上）

1. 部署本分支，重建前端（如果也切 PR #13 分支）+ 重启 admin。
2. 在 admin UI 点击某个冷却账号（如 FruitLoopsgls 107%）的 ↻ 同步按钮，或者等自适应轮询触发 \`/api/sync-usage-all\`。
3. 观察：
   - \`config/terminals.json\`：该账号上 \`mode: 'auto'\` 的终端 \`accountId\` 几秒内被改成热账号 id。
   - admin UI 下一次 15s 轮询后，终端列表里这些 auto 终端显示绑定在新账号上。
   - manual 模式终端保持原 accountId 不变。
4. proxy 端：\`config/terminals.json\` 被覆写后 5s 内，proxy 的 \`fs.watch\`/轮询 pickup 新绑定，下次请求按新绑定路由。

## 与 PR #11 的关系

- **PR #11（路由层）**：请求到达时绕开冷却账号，避免 429 往返。浏览器不在线也生效。
- **PR #17 / 本 PR（迁移层）**：冷却被侦测到时就更新 terminals.json。UI 上看得见迁移。

两者互补。如果只合 PR #11，UI 上依然显示终端挂在冷却账号上；如果只合本 PR，没有浏览器开着就不会触发迁移（但后续请求会走 PR #11 的兜底）。