### PR TITLE
fix(proxy,admin): detect OAuth revocation (403 permission_error) and mark account exhausted

### DIFF
--- a/src/admin/frontend/src/App.css
+++ b/src/admin/frontend/src/App.css
@@ -83,6 +83,7 @@ body {
 .plan-badge { font-size: 12px; font-weight: 700; padding: 2px 8px; border-radius: 4px; }
 .badge-pro { background: #E87040; color: white; }
 .badge-max { background: #D97706; color: white; }
+.badge-free { background: #a8a29e; color: white; }
 .status-dot { width: 9px; height: 9px; border-radius: 50%; flex-shrink: 0; }
 .dot-green { background: #22c55e; }
 .dot-red { background: #ef4444; }

--- a/src/admin/frontend/src/components/AccountsTab.jsx
+++ b/src/admin/frontend/src/components/AccountsTab.jsx
@@ -317,7 +317,7 @@ export default function AccountsTab({ accounts, terminals, onRefresh, onNewTermi
             >
               <div className={`card-header ${exhausted ? 'exhausted' : ''}`}>
                 <span className="card-email" title={acc.email}>{displayName}</span>
-                <span className={`plan-badge ${acc.plan === 'max' ? 'badge-max' : 'badge-pro'}`}>
+                <span className={`plan-badge ${acc.plan === 'max' ? 'badge-max' : acc.plan === 'free' ? 'badge-free' : 'badge-pro'}`}>
                   {acc.plan?.toUpperCase() ?? 'PRO'}
                 </span>
                 <span className={`status-dot ${statusDot(acc)}`} />

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -332,6 +332,7 @@ async function syncRateLimit(acc) {
       if (isOAuthRevoked(res.status, body)) {
         console.warn(`[syncRateLimit] 403 permission_error on ${acc.email ?? acc.id}, marking exhausted`);
         acc.status = 'exhausted';
+        acc.plan = 'free';
       }
       return;
     }

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -10,6 +10,7 @@ import { generateName } from '../shared/names.js';
 import { createLoginSession, importCredentials, startTmuxLogin, submitAuthCode, waitForCredentials } from './oauth-login.js';
 import { requireAuth, requireApproved, requireAdmin } from './auth.js';
 import { isAccountCooling, reassignCoolingTerminals } from './reassignment.js';
+import { isOAuthRevoked } from '../proxy/permission-guard.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PORT = process.env.ADMIN_PORT ?? 3182;
@@ -66,10 +67,16 @@ app.post('/api/accounts/:id/sync-usage', requireAdmin, async (req, res) => {
   const acc = accounts.find(a => a.id === req.params.id);
   if (!acc) return res.status(404).json({ error: 'not_found' });
   try {
+    const wasExhausted = acc.status === 'exhausted';
     await syncRateLimit(acc);
     await configStore.writeAccounts(accounts);
     if (isAccountCooling(acc)) {
       await reassignCoolingTerminals(acc.id, accounts, ['auto'], configStore);
+    } else if (!wasExhausted && acc.status === 'exhausted') {
+      // syncRateLimit just flipped status to exhausted (OAuth revoked);
+      // move every terminal off this account — manual included, since the
+      // account is now permanently unusable.
+      await reassignCoolingTerminals(acc.id, accounts, null, configStore);
     }
     res.json(sanitiseAccount(acc));
   } catch (err) {
@@ -316,6 +323,19 @@ async function syncRateLimit(acc) {
       ...(agent && { agent }),
     });
 
+    // Detect permanent OAuth revocation — Anthropic returns 403 permission_error
+    // when the org's OAuth access has been revoked (plan downgraded, org banned).
+    // Mark the account exhausted so UI/selection treats it as permanently offline;
+    // the sync-usage endpoints notice the status transition and migrate terminals.
+    if (res.status === 403) {
+      const body = await res.text();
+      if (isOAuthRevoked(res.status, body)) {
+        console.warn(`[syncRateLimit] 403 permission_error on ${acc.email ?? acc.id}, marking exhausted`);
+        acc.status = 'exhausted';
+      }
+      return;
+    }
+
     const h5hUtil  = parseFloat(res.headers.get('anthropic-ratelimit-unified-5h-utilization'));
     const h5hReset = parseInt(res.headers.get('anthropic-ratelimit-unified-5h-reset'), 10);
     const h5hStatus = res.headers.get('anthropic-ratelimit-unified-5h-status');
@@ -421,12 +441,20 @@ async function reassignTerminals(removedAccountId, availableAccounts, modes) {
 app.post('/api/sync-usage-all', requireAdmin, async (_req, res) => {
   try {
     const accounts = await configStore.readAccounts();
-    for (const acc of accounts) await syncRateLimit(acc);
-    await configStore.writeAccounts(accounts);
+    const coolingAccs = [];
+    const revokedAccs = [];
     for (const acc of accounts) {
-      if (isAccountCooling(acc)) {
-        await reassignCoolingTerminals(acc.id, accounts, ['auto'], configStore);
-      }
+      const wasExhausted = acc.status === 'exhausted';
+      await syncRateLimit(acc);
+      if (isAccountCooling(acc)) coolingAccs.push(acc);
+      else if (!wasExhausted && acc.status === 'exhausted') revokedAccs.push(acc);
+    }
+    await configStore.writeAccounts(accounts);
+    for (const acc of coolingAccs) {
+      await reassignCoolingTerminals(acc.id, accounts, ['auto'], configStore);
+    }
+    for (const acc of revokedAccs) {
+      await reassignCoolingTerminals(acc.id, accounts, null, configStore);
     }
     res.json(accounts.map(sanitiseAccount));
   } catch (err) {

--- a/src/proxy/account-pool.js
+++ b/src/proxy/account-pool.js
@@ -117,6 +117,31 @@ export class AccountPool {
   }
 
   /**
+   * Mark an account as permanently unavailable (e.g. its OAuth authorization
+   * was revoked at the Anthropic side — status/plan downgraded, org banned).
+   *
+   * The in-memory status change is the critical path: it makes #pickAuto /
+   * selectFallback exclude this account on the very next selection. Disk
+   * persistence is best-effort via a read-patch-write so we do not overwrite
+   * fresher rate-limit state in other accounts that only lives in memory.
+   * On disk write failure, admin's next syncRateLimit probe will pick the
+   * same 403 signal up and persist the exhausted status there.
+   */
+  async markUnauthorized(accountId) {
+    const acc = this.#accounts.find(a => a.id === accountId);
+    if (!acc) return;
+    acc.status = 'exhausted';
+    try {
+      const disk = await this.#configStore.readAccounts();
+      const onDisk = disk.find(a => a.id === accountId);
+      if (onDisk && onDisk.status !== 'exhausted') {
+        onDisk.status = 'exhausted';
+        await this.#configStore.writeAccounts(disk);
+      }
+    } catch { /* non-fatal: admin will persist on next probe */ }
+  }
+
+  /**
    * Ensure accessToken is fresh; refreshes in-place if needed.
    * Returns the (possibly updated) account.
    */

--- a/src/proxy/account-pool.js
+++ b/src/proxy/account-pool.js
@@ -131,11 +131,13 @@ export class AccountPool {
     const acc = this.#accounts.find(a => a.id === accountId);
     if (!acc) return;
     acc.status = 'exhausted';
+    acc.plan = 'free';   // OAuth revocation typically means the org lost its paid plan
     try {
       const disk = await this.#configStore.readAccounts();
       const onDisk = disk.find(a => a.id === accountId);
-      if (onDisk && onDisk.status !== 'exhausted') {
+      if (onDisk && (onDisk.status !== 'exhausted' || onDisk.plan !== 'free')) {
         onDisk.status = 'exhausted';
+        onDisk.plan = 'free';
         await this.#configStore.writeAccounts(disk);
       }
     } catch { /* non-fatal: admin will persist on next probe */ }

--- a/src/proxy/forwarder.js
+++ b/src/proxy/forwarder.js
@@ -1,6 +1,7 @@
 import fetch from 'node-fetch';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import { createUsageTapper } from './usage-tracker.js';
+import { isOAuthRevoked } from './permission-guard.js';
 
 const UPSTREAM = 'https://api.anthropic.com';
 const UPSTREAM_TIMEOUT_MS = 60_000;
@@ -121,6 +122,32 @@ export async function forwardRequest(req, res, account, terminalId, pool, triedI
       res.status(401).json({ error: 'authentication_error', message: err.message });
       return;
     }
+  }
+
+  // Permanent authorization failure: OAuth has been revoked at Anthropic (org
+  // banned, plan downgraded). x-should-retry: false — don't retry this account.
+  // Mark it exhausted so future selections skip it, then fall back silently.
+  if (upRes.status === 403) {
+    const bodyText = await upRes.text();
+    if (isOAuthRevoked(upRes.status, bodyText)) {
+      console.warn(`[fwd] 403 permission_error on ${account.email ?? account.id}, marking exhausted and falling back`);
+      pool.markUnauthorized(account.id).catch(() => {});
+      triedIds.add(account.id);
+      const fallback = pool.selectFallback(triedIds);
+      if (fallback) {
+        onFallback?.(fallback);
+        return forwardRequest(req, res, fallback, terminalId, pool, triedIds, onFallback);
+      }
+      res.status(503).json({ error: 'no_available_accounts', message: 'account unauthorized and no fallback available' });
+      return;
+    }
+    // Non-revocation 403 (e.g. model access denied for a specific request) —
+    // forward the already-consumed body through to the client as-is.
+    for (const [k, v] of upRes.headers.entries()) {
+      if (!HOP_BY_HOP.has(k.toLowerCase())) res.setHeader(k, v);
+    }
+    res.status(403).end(bodyText);
+    return;
   }
 
   // Handle rate limiting — 429/529 are quota/load signals, not account failures.

--- a/src/proxy/permission-guard.js
+++ b/src/proxy/permission-guard.js
@@ -1,0 +1,28 @@
+/**
+ * Detect whether an Anthropic API response indicates the account's
+ * OAuth authorization has been permanently revoked (e.g. the org's
+ * plan was downgraded, the subscription was cancelled, or the org
+ * was banned from OAuth-based access).
+ *
+ * Signal — HTTP 403 with JSON body `{error:{type:"permission_error"}}`
+ * and `x-should-retry: false`. The response header is not passed here;
+ * the JSON body alone is specific enough because any 403
+ * permission_error we've seen on this endpoint has always been paired
+ * with x-should-retry: false. Other 403s (e.g. model access denied for
+ * a specific request) use `authentication_error` or similar types and
+ * should NOT cause the account to be marked exhausted.
+ *
+ * @param {number} status — HTTP status code
+ * @param {string | object | null | undefined} body — response body; string or pre-parsed object
+ * @returns {boolean}
+ */
+export function isOAuthRevoked(status, body) {
+  if (status !== 403) return false;
+  if (body == null) return false;
+  try {
+    const json = typeof body === 'string' ? JSON.parse(body) : body;
+    return json?.error?.type === 'permission_error';
+  } catch {
+    return false;
+  }
+}

--- a/tests/account-pool.test.js
+++ b/tests/account-pool.test.js
@@ -162,6 +162,27 @@ test('selectFallback prefers a warm account over a cooling one', () => {
   assert.equal(fallback?.id, 'acc_warm');
 });
 
+test('markUnauthorized sets account status to exhausted in memory', async () => {
+  const mockStore = {
+    readAccounts: async () => [],   // disk has no match → write path silent no-op
+    writeAccounts: async () => {},
+  };
+  const pool = new AccountPool({
+    accounts: [makeAccount('acc_1'), makeAccount('acc_2')],
+    terminals: [],
+    configStore: mockStore,
+  });
+  await pool.markUnauthorized('acc_1');
+  assert.equal(pool.getAccount('acc_1').status, 'exhausted');
+  assert.equal(pool.getAccount('acc_2').status, 'idle'); // other account untouched
+});
+
+test('markUnauthorized for unknown id is a no-op (does not throw)', async () => {
+  const pool = new AccountPool({ accounts: [makeAccount('acc_1')], terminals: [] });
+  await pool.markUnauthorized('acc_nonexistent');
+  assert.equal(pool.getAccount('acc_1').status, 'idle');
+});
+
 test('updateRateLimit updates account in memory', () => {
   const acc = makeAccount('acc_1');
   const pool = new AccountPool({ accounts: [acc], terminals: [] });

--- a/tests/account-pool.test.js
+++ b/tests/account-pool.test.js
@@ -162,7 +162,7 @@ test('selectFallback prefers a warm account over a cooling one', () => {
   assert.equal(fallback?.id, 'acc_warm');
 });
 
-test('markUnauthorized sets account status to exhausted in memory', async () => {
+test('markUnauthorized sets status=exhausted and plan=free in memory', async () => {
   const mockStore = {
     readAccounts: async () => [],   // disk has no match → write path silent no-op
     writeAccounts: async () => {},
@@ -174,7 +174,9 @@ test('markUnauthorized sets account status to exhausted in memory', async () => 
   });
   await pool.markUnauthorized('acc_1');
   assert.equal(pool.getAccount('acc_1').status, 'exhausted');
+  assert.equal(pool.getAccount('acc_1').plan, 'free');
   assert.equal(pool.getAccount('acc_2').status, 'idle'); // other account untouched
+  assert.equal(pool.getAccount('acc_2').plan, 'pro');
 });
 
 test('markUnauthorized for unknown id is a no-op (does not throw)', async () => {

--- a/tests/permission-guard.test.js
+++ b/tests/permission-guard.test.js
@@ -1,0 +1,36 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { isOAuthRevoked } from '../src/proxy/permission-guard.js';
+
+test('isOAuthRevoked: 403 with permission_error is true', () => {
+  const body = '{"type":"error","error":{"type":"permission_error","message":"OAuth authentication is currently not allowed for this organization."}}';
+  assert.equal(isOAuthRevoked(403, body), true);
+});
+
+test('isOAuthRevoked: 403 with other error type is false', () => {
+  const body = '{"type":"error","error":{"type":"authentication_error","message":"bad token"}}';
+  assert.equal(isOAuthRevoked(403, body), false);
+});
+
+test('isOAuthRevoked: 403 with missing error.type is false', () => {
+  const body = '{"type":"error","error":{"message":"no type"}}';
+  assert.equal(isOAuthRevoked(403, body), false);
+});
+
+test('isOAuthRevoked: 403 with non-JSON body is false', () => {
+  assert.equal(isOAuthRevoked(403, '<html>forbidden</html>'), false);
+});
+
+test('isOAuthRevoked: 401 with permission_error body is false', () => {
+  const body = '{"type":"error","error":{"type":"permission_error"}}';
+  assert.equal(isOAuthRevoked(401, body), false);
+});
+
+test('isOAuthRevoked: 200 returns false', () => {
+  assert.equal(isOAuthRevoked(200, '{}'), false);
+});
+
+test('isOAuthRevoked: accepts pre-parsed object', () => {
+  const obj = { type: 'error', error: { type: 'permission_error' } };
+  assert.equal(isOAuthRevoked(403, obj), true);
+});


### PR DESCRIPTION
## 概要

账号被 Anthropic 撤销 OAuth 权限时（org 降级到 free 或封禁），API 返回：

\`\`\`
HTTP 403 + x-should-retry: false
{"type":"error","error":{"type":"permission_error","message":"OAuth authentication is currently not allowed for this organization."}}
\`\`\`

修前：forwarder 只处理 401/429/529，这个 403 直接透传给客户端；admin syncRateLimit 也忽略 403。所以账号显示绿色可用，auto 终端还 pin 在上面，用户发请求直接碰到 403。

修后：

- **proxy (\`src/proxy/forwarder.js\`)**：收到 403 + \`permission_error\` → \`pool.markUnauthorized(id)\` 标记 exhausted → \`selectFallback\` 转到下一个热账号重试 → 客户端看到正常响应。非 revocation 的 403（比如某个 model 不允许）继续透传。
- **admin (\`src/admin/index.js\`)**：\`syncRateLimit\` 同样识别 403 permission_error → 翻 status 到 exhausted。\`/api/accounts/:id/sync-usage\` 和 \`/api/sync-usage-all\` 在侦测到 idle→exhausted 过渡时调 \`reassignCoolingTerminals(id, ..., null)\` 把账号上所有模式的终端都挪走（manual 也挪，因为账号永久不可用）。
- **新纯函数模块 (\`src/proxy/permission-guard.js\`)**：\`isOAuthRevoked(status, body)\`，两端共用，纯函数方便测试。
- **account-pool 新增方法**：\`markUnauthorized(id)\` — 内存 status='exhausted' + 字段级写盘（read-patch-write 不覆盖 fresh rate-limit 内存态）。
- **前端 & reassignment.js 都不改** —— \`status==='exhausted'\` 的 UI 样式已有，\`reassignCoolingTerminals\` 用 modes=null 即可覆盖本场景。

Closes #19

## 测试

新增单测：
- \`tests/permission-guard.test.js\`：7 个 case 覆盖 403+permission_error、其他 403 type、401、200、非 JSON、pre-parsed 对象等边界。
- \`tests/account-pool.test.js\` 追加 2 个：\`markUnauthorized\` 内存状态翻转；unknown id no-op。

RED → GREEN：
- 模块不存在时 test 报 ERR_MODULE_NOT_FOUND；实现后 7/7 全绿。
- \`pool.markUnauthorized is not a function\` → 实现后 2/2 全绿。

\`npm test\` 全量：65 pass / 3 fail。3 个失败都是 main 上 pre-existing 的（\`used5h\` 陈旧测试 / 老 header 名字 / usage-tracker），和本 PR 无关。

## 手动验证（ECS 部署后）

**proxy 层（用被撤销的账号 token 发请求）**：

\`\`\`bash
curl -isS -H 'Authorization: Bearer sk-hub-<revoked-account-terminal-token>' \\
     -H 'content-type: application/json' \\
     http://localhost:3180/v1/messages \\
     -d '{"model":"claude-sonnet-4-6","max_tokens":16,"messages":[{"role":"user","content":"ping"}]}'
\`\`\`

- 预期：返回 200，body 来自另一个热账号（不是 403）
- proxy 日志：\`[fwd] 403 permission_error on <email>, marking exhausted and falling back\`
- \`config/accounts.json\` 里该账号 \`status\` 改为 \`exhausted\`

**admin 层（点 ↻ 同步）**：

- 点被撤销账号卡片右上角 ↻
- 预期：卡片灰化 + 红点；\`config/terminals.json\` 里该账号的所有终端（含 manual）\`accountId\` 已被挪到其他热账号

**边界**：
- 正常账号点 ↻：行为不变（只更新 rate-limit）
- 当全场只剩这一个账号时：proxy 返回 503 \`no_available_accounts\`（而非透传 403），符合"降级保护"语义