### PR TITLE
fix(admin,proxy): sync OAuth plan tier after downgrade

### DIFF
--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -7,10 +7,18 @@ import { randomBytes } from 'node:crypto';
 import { configStore } from '../shared/config.js';
 import { isExpired, refreshToken } from '../proxy/token-manager.js';
 import { generateName } from '../shared/names.js';
-import { createLoginSession, importCredentials, startTmuxLogin, submitAuthCode, waitForCredentials } from './oauth-login.js';
+import {
+  createLoginSession,
+  importCredentials,
+  fetchProfilePlanTier,
+  startTmuxLogin,
+  submitAuthCode,
+  waitForCredentials,
+} from './oauth-login.js';
 import { requireAuth, requireApproved, requireAdmin } from './auth.js';
 import { isAccountCooling, reassignCoolingTerminals } from './reassignment.js';
 import { isOAuthRevoked } from '../proxy/permission-guard.js';
+import { extractPlanFromAccessTokenJwt, normalizePlanTier } from '../shared/oauth-plan.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PORT = process.env.ADMIN_PORT ?? 3182;
@@ -51,8 +59,12 @@ app.post('/api/accounts/:id/refresh-token', requireAdmin, async (req, res) => {
     // Re-fetch email after token refresh (fixes accounts imported with placeholder email)
     const meData = await fetchMe(acc.credentials.accessToken);
     if (meData.email) acc.email = meData.email;
-    // Plan comes from subscriptionType in the refreshed credentials
-    if (update.credentials.subscriptionType) acc.plan = update.credentials.subscriptionType;
+    const fromMe = normalizePlanTier(meData.subscriptionType);
+    const fromCreds = normalizePlanTier(update.credentials.subscriptionType);
+    if (fromCreds) acc.plan = fromCreds;
+    else if (fromMe) acc.plan = fromMe;
+    if (fromCreds) acc.credentials.subscriptionType = fromCreds;
+    else if (fromMe) acc.credentials.subscriptionType = fromMe;
     // Probe Anthropic API to sync current rate limit usage from response headers
     await syncRateLimit(acc);
     await configStore.writeAccounts(accounts);
@@ -291,6 +303,30 @@ app.post('/api/oauth/import-manual/:sessionId', requireAdmin, async (req, res) =
 
 // ── Helpers ───────────────────────────────────────────────────────────────
 
+/** Throttle remote profile fetches per account (JWT decode is cheap; this is not). */
+const profilePlanThrottle = new Map();
+const PROFILE_PLAN_MIN_MS = 5 * 60 * 1000;
+
+/**
+ * Refresh acc.plan from /api/oauth/profile (throttled) and JWT claims (cheap).
+ * See #21 — imported plan tier can stay "pro" after Anthropic downgrade.
+ */
+async function refreshAccountPlanFromAnthropic(acc) {
+  const token = acc.credentials?.accessToken;
+  if (!token) return;
+
+  const last = profilePlanThrottle.get(acc.id) ?? 0;
+  const doProfile = Date.now() - last >= PROFILE_PLAN_MIN_MS;
+  if (doProfile) profilePlanThrottle.set(acc.id, Date.now());
+
+  let tier = doProfile ? await fetchProfilePlanTier(token) : null;
+  if (!tier) tier = extractPlanFromAccessTokenJwt(token);
+  if (tier) {
+    acc.plan = tier;
+    acc.credentials.subscriptionType = tier;
+  }
+}
+
 /**
  * Make a minimal probe request to Anthropic to read current rate-limit headers,
  * then update acc.rateLimit in-place. Non-fatal: errors are silently ignored.
@@ -300,7 +336,10 @@ async function syncRateLimit(acc) {
     if (isExpired(acc)) {
       const update = await refreshToken(acc);
       Object.assign(acc.credentials, update.credentials);
+      const st = normalizePlanTier(acc.credentials.subscriptionType);
+      if (st) acc.plan = st;
     }
+    await refreshAccountPlanFromAnthropic(acc);
     const fetch = (await import('node-fetch')).default;
     const { HttpsProxyAgent } = await import('https-proxy-agent');
     const proxyUrl = process.env.HTTPS_PROXY || process.env.https_proxy

--- a/src/admin/oauth-login.js
+++ b/src/admin/oauth-login.js
@@ -5,10 +5,12 @@ import { exec, execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import fetch from 'node-fetch';
 import { HttpsProxyAgent } from 'https-proxy-agent';
+import { normalizePlanTier, pickPlanFromAnthropicProfileBody } from '../shared/oauth-plan.js';
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
 const ROLES_URL = 'https://api.anthropic.com/api/oauth/claude_cli/roles';
+const PROFILE_URL = 'https://api.anthropic.com/api/oauth/profile';
 
 const proxyUrl = process.env.HTTPS_PROXY || process.env.https_proxy
                || process.env.HTTP_PROXY  || process.env.http_proxy;
@@ -202,10 +204,14 @@ async function killTmuxSession(tmuxSession) {
 }
 
 function buildAccount(creds, meData) {
+  const plan =
+    normalizePlanTier(creds.subscriptionType) ??
+    normalizePlanTier(meData.subscriptionType) ??
+    'pro';
   return {
     id: `acc_${randomBytes(6).toString('hex')}`,
     email: meData.email ?? 'unknown@example.com',
-    plan: creds.subscriptionType ?? 'pro',
+    plan,
     credentials: {
       accessToken: creds.accessToken,
       refreshToken: creds.refreshToken ?? null,
@@ -233,9 +239,28 @@ export async function fetchMe(accessToken) {
     // email is embedded in organization_name: "user@example.com's Organization"
     const orgName = data.organization_name ?? '';
     const email = orgName.replace(/'s Organization$/i, '').trim() || null;
-    return { email };
+    const planFromRoles = pickPlanFromAnthropicProfileBody(data);
+    return { email, subscriptionType: planFromRoles ?? undefined };
   } catch {
     return {};
+  }
+}
+
+/**
+ * GET /api/oauth/profile — current subscription tier when OAuth is still valid.
+ * @returns {'free' | 'pro' | 'max' | null}
+ */
+export async function fetchProfilePlanTier(accessToken) {
+  try {
+    const res = await fetch(PROFILE_URL, {
+      headers: { authorization: `Bearer ${accessToken}` },
+      ...(proxyAgent && { agent: proxyAgent }),
+    });
+    if (!res.ok) return null;
+    const data = await res.json();
+    return pickPlanFromAnthropicProfileBody(data);
+  } catch {
+    return null;
   }
 }
 

--- a/src/proxy/account-pool.js
+++ b/src/proxy/account-pool.js
@@ -2,6 +2,7 @@ import { watch } from 'node:fs';
 import { CircuitBreaker } from './circuit-breaker.js';
 import { RateQueue } from './rate-queue.js';
 import { isExpired, refreshToken } from './token-manager.js';
+import { normalizePlanTier } from '../shared/oauth-plan.js';
 import { configStore } from '../shared/config.js';
 
 export class AccountPool {
@@ -151,6 +152,8 @@ export class AccountPool {
     if (!isExpired(account)) return account;
     const update = await refreshToken(account);
     Object.assign(account.credentials, update.credentials);
+    const st = normalizePlanTier(account.credentials.subscriptionType);
+    if (st) account.plan = st;
     await this.#configStore.writeAccounts(this.#accounts).catch(() => {});
     return account;
   }

--- a/src/proxy/token-manager.js
+++ b/src/proxy/token-manager.js
@@ -1,5 +1,6 @@
 import fetch from 'node-fetch';
 import { HttpsProxyAgent } from 'https-proxy-agent';
+import { mergeSubscriptionFromOAuthTokenResponse } from '../shared/oauth-plan.js';
 
 const TOKEN_URL = 'https://platform.claude.com/v1/oauth/token';
 const CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
@@ -40,12 +41,12 @@ export async function refreshToken(account) {
   }
 
   const data = await res.json();
-  return {
-    credentials: {
-      accessToken: data.access_token,
-      refreshToken: data.refresh_token ?? account.credentials.refreshToken,
-      expiresAt: Date.now() + (data.expires_in ?? 3600) * 1000,
-      scopes: account.credentials.scopes,
-    },
+  const credentials = {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token ?? account.credentials.refreshToken,
+    expiresAt: Date.now() + (data.expires_in ?? 3600) * 1000,
+    scopes: account.credentials.scopes,
   };
+  mergeSubscriptionFromOAuthTokenResponse(credentials, data);
+  return { credentials };
 }

--- a/src/shared/oauth-plan.js
+++ b/src/shared/oauth-plan.js
@@ -1,0 +1,97 @@
+/**
+ * Normalize Anthropic / Claude OAuth subscription labels to hub account.plan values.
+ * @param {unknown} raw
+ * @returns {'free' | 'pro' | 'max' | null}
+ */
+export function normalizePlanTier(raw) {
+  if (raw == null || raw === '') return null;
+  const s = String(raw).trim().toLowerCase();
+  if (!s) return null;
+  if (s === 'free' || s === 'free_tier' || s === 'none') return 'free';
+  if (s === 'max' || s.includes('max')) return 'max';
+  if (s === 'pro' || s.includes('pro') || s === 'team' || s.includes('business')) return 'pro';
+  return null;
+}
+
+/**
+ * Merge subscriptionType from platform.claude.com OAuth token JSON into credentials.
+ * @param {Record<string, unknown>} credentials — mutated in place
+ * @param {Record<string, unknown>} data — token endpoint JSON body
+ */
+export function mergeSubscriptionFromOAuthTokenResponse(credentials, data) {
+  if (!data || typeof data !== 'object') return;
+  const direct =
+    data.subscription_type ??
+    data.subscriptionType ??
+    data.subscription?.type ??
+    data.subscription?.tier ??
+    data.account?.subscription_type ??
+    data.account?.subscriptionType;
+  const tier = normalizePlanTier(direct);
+  if (tier) credentials.subscriptionType = tier;
+}
+
+/**
+ * Best-effort: read subscription tier from a JWT-shaped OAuth access token (no verify).
+ * @param {string | undefined} accessToken
+ * @returns {'free' | 'pro' | 'max' | null}
+ */
+export function extractPlanFromAccessTokenJwt(accessToken) {
+  if (!accessToken || typeof accessToken !== 'string') return null;
+  const parts = accessToken.split('.');
+  if (parts.length !== 3) return null;
+  try {
+    const b = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+    const pad = b.length % 4 ? '='.repeat(4 - (b.length % 4)) : '';
+    const json = Buffer.from(b + pad, 'base64').toString('utf8');
+    const payload = JSON.parse(json);
+    return deepFindSubscriptionTier(payload);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * @param {unknown} obj
+ * @param {number} depth
+ * @returns {'free' | 'pro' | 'max' | null}
+ */
+function deepFindSubscriptionTier(obj, depth = 0) {
+  if (!obj || typeof obj !== 'object' || depth > 10) return null;
+  if (Array.isArray(obj)) {
+    for (const el of obj) {
+      const t = deepFindSubscriptionTier(el, depth + 1);
+      if (t) return t;
+    }
+    return null;
+  }
+  for (const [k, v] of Object.entries(obj)) {
+    const kl = k.toLowerCase();
+    if (
+      (kl === 'subscriptiontype' ||
+        kl === 'subscription_type' ||
+        kl === 'plantier' ||
+        kl === 'plan_tier' ||
+        kl === 'rate_limittier' ||
+        kl === 'claude_subscription') &&
+      (typeof v === 'string' || typeof v === 'number')
+    ) {
+      const tier = normalizePlanTier(v);
+      if (tier) return tier;
+    }
+    if (v && typeof v === 'object') {
+      const inner = deepFindSubscriptionTier(v, depth + 1);
+      if (inner) return inner;
+    }
+  }
+  return null;
+}
+
+/**
+ * Pick plan from GET /api/oauth/profile (or similar) JSON body.
+ * @param {unknown} data
+ * @returns {'free' | 'pro' | 'max' | null}
+ */
+export function pickPlanFromAnthropicProfileBody(data) {
+  return deepFindSubscriptionTier(data);
+}

--- a/tests/oauth-plan.test.js
+++ b/tests/oauth-plan.test.js
@@ -1,0 +1,47 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  normalizePlanTier,
+  mergeSubscriptionFromOAuthTokenResponse,
+  extractPlanFromAccessTokenJwt,
+  pickPlanFromAnthropicProfileBody,
+} from '../src/shared/oauth-plan.js';
+
+test('normalizePlanTier maps common labels (#21)', () => {
+  assert.equal(normalizePlanTier('PRO'), 'pro');
+  assert.equal(normalizePlanTier('max'), 'max');
+  assert.equal(normalizePlanTier('FREE_TIER'), 'free');
+  assert.equal(normalizePlanTier('none'), 'free');
+  assert.equal(normalizePlanTier('unknown_tier'), null);
+});
+
+test('mergeSubscriptionFromOAuthTokenResponse reads OAuth token JSON (#21)', () => {
+  const creds = { accessToken: 'x' };
+  mergeSubscriptionFromOAuthTokenResponse(creds, {
+    subscription_type: 'free',
+  });
+  assert.equal(creds.subscriptionType, 'free');
+});
+
+test('mergeSubscriptionFromOAuthTokenResponse reads nested account fields (#21)', () => {
+  const creds = {};
+  mergeSubscriptionFromOAuthTokenResponse(creds, {
+    account: { subscription_type: 'max' },
+  });
+  assert.equal(creds.subscriptionType, 'max');
+});
+
+test('extractPlanFromAccessTokenJwt reads nested subscription in JWT payload (#21)', () => {
+  const payload = Buffer.from(JSON.stringify({ meta: { subscriptionType: 'free' } })).toString(
+    'base64url',
+  );
+  const tok = `x.${payload}.z`;
+  assert.equal(extractPlanFromAccessTokenJwt(tok), 'free');
+});
+
+test('pickPlanFromAnthropicProfileBody finds tier in nested object (#21)', () => {
+  const tier = pickPlanFromAnthropicProfileBody({
+    user: { subscription_type: 'pro' },
+  });
+  assert.equal(tier, 'pro');
+});


### PR DESCRIPTION
## Summary
- Parse `subscription_type` / nested account fields from `platform.claude.com` OAuth refresh JSON and persist into `credentials.subscriptionType` (`token-manager`, `account-pool` refresh path).
- During admin `syncRateLimit`, refresh `acc.plan` from Anthropic `/api/oauth/profile` (every 5 min per account) with JWT payload as fallback; keeps badge in sync after downgrade (#21).
- `fetchMe` (roles) and new-account `buildAccount` use normalized tier labels.

Closes #21

## Test plan
- [x] `node --test tests/oauth-plan.test.js` — all pass (encodes #21 parsing / merge behaviour).
- [x] `npm test` — same 3 failures as current `origin/main` (account-pool selection, usage-tracker); no new regressions from this branch.
- [ ] Manual: deploy admin, open 账号 tab, trigger sync on a downgraded OAuth account — badge should show **FREE** when profile/JWT/token refresh exposes `free` (within profile throttle window).


Made with [Cursor](https://cursor.com)