### PR TITLE
fix(proxy): preserve exhausted/free state on refresh writes

### DIFF
--- a/src/proxy/account-pool.js
+++ b/src/proxy/account-pool.js
@@ -9,6 +9,7 @@ export class AccountPool {
   #circuitBreakers = new Map(); // accountId → CircuitBreaker
   #rateQueues = new Map();       // accountId → RateQueue
   #configStore;
+  #refreshTokenFn;
   #watcher = null;
   #refreshTimer = null;
 
@@ -18,6 +19,7 @@ export class AccountPool {
    */
   constructor(opts = {}) {
     this.#configStore = opts.configStore ?? configStore;
+    this.#refreshTokenFn = opts.refreshTokenFn ?? refreshToken;
     if (opts.accounts) {
       this.#accounts = opts.accounts;
     }
@@ -149,9 +151,9 @@ export class AccountPool {
    */
   async ensureFreshToken(account) {
     if (!isExpired(account)) return account;
-    const update = await refreshToken(account);
+    const update = await this.#refreshTokenFn(account);
     Object.assign(account.credentials, update.credentials);
-    await this.#configStore.writeAccounts(this.#accounts).catch(() => {});
+    await this.#patchAccountCredentialsOnDisk(account.id, update.credentials).catch(() => {});
     return account;
   }
 
@@ -278,10 +280,16 @@ export class AccountPool {
         for (const freshAcc of fresh) {
           const mem = this.#accounts.find(a => a.id === freshAcc.id);
           if (mem) {
-            // Only update credentials if they changed (admin refreshed token)
-            if (freshAcc.credentials?.accessToken !== mem.credentials?.accessToken) {
-              Object.assign(mem.credentials, freshAcc.credentials);
-            }
+            // Pull durable fields from disk so proxy memory does not overwrite
+            // fresher admin / persistence state on a later write.
+            mem.email = freshAcc.email;
+            mem.nickname = freshAcc.nickname;
+            mem.status = freshAcc.status;
+            mem.plan = freshAcc.plan;
+            mem.cooldownUntil = freshAcc.cooldownUntil;
+            mem.addedAt = freshAcc.addedAt;
+            mem.credentials ??= {};
+            if (freshAcc.credentials) Object.assign(mem.credentials, freshAcc.credentials);
           }
         }
         // Add/remove accounts that were added/deleted via admin
@@ -311,5 +319,13 @@ export class AccountPool {
       }
     }, 10 * 60 * 1000);
     this.#refreshTimer.unref();
+  }
+
+  async #patchAccountCredentialsOnDisk(accountId, credentials) {
+    const disk = await this.#configStore.readAccounts();
+    const onDisk = disk.find(a => a.id === accountId);
+    if (!onDisk) return;
+    onDisk.credentials = { ...(onDisk.credentials ?? {}), ...credentials };
+    await this.#configStore.writeAccounts(disk);
   }
 }

--- a/tests/account-pool.test.js
+++ b/tests/account-pool.test.js
@@ -6,7 +6,7 @@ function makeAccount(id, opts = {}) {
   return {
     id,
     email: `${id}@example.com`,
-    plan: 'pro',
+    plan: opts.plan ?? 'pro',
     credentials: { accessToken: 'tok', refreshToken: 'ref', expiresAt: Date.now() + 3600000, scopes: ['user:inference'] },
     status: opts.status ?? 'idle',
     cooldownUntil: opts.cooldownUntil ?? null,
@@ -183,6 +183,46 @@ test('markUnauthorized for unknown id is a no-op (does not throw)', async () => 
   const pool = new AccountPool({ accounts: [makeAccount('acc_1')], terminals: [] });
   await pool.markUnauthorized('acc_nonexistent');
   assert.equal(pool.getAccount('acc_1').status, 'idle');
+});
+
+test('ensureFreshToken preserves fresher exhausted/free state on disk while updating credentials', async () => {
+  let written = null;
+  const diskAccounts = [
+    makeAccount('acc_1', { status: 'exhausted', plan: 'free' }),
+  ];
+  const mockStore = {
+    readAccounts: async () => structuredClone(diskAccounts),
+    writeAccounts: async (data) => { written = structuredClone(data); },
+  };
+  const pool = new AccountPool({
+    accounts: [
+      {
+        ...makeAccount('acc_1', { status: 'idle', plan: 'pro' }),
+        credentials: {
+          accessToken: 'old-token',
+          refreshToken: 'refresh-token',
+          expiresAt: 0,
+          scopes: ['user:inference'],
+        },
+      },
+    ],
+    terminals: [],
+    configStore: mockStore,
+    refreshTokenFn: async () => ({
+      credentials: {
+        accessToken: 'new-token',
+        refreshToken: 'refresh-token',
+        expiresAt: Date.now() + 3600000,
+        scopes: ['user:inference'],
+      },
+    }),
+  });
+
+  await pool.ensureFreshToken(pool.getAccount('acc_1'));
+
+  assert.equal(written[0].status, 'exhausted');
+  assert.equal(written[0].plan, 'free');
+  assert.equal(written[0].credentials.accessToken, 'new-token');
 });
 
 test('updateRateLimit updates account in memory', () => {


### PR DESCRIPTION
## Summary
- patch proxy token-refresh persistence so `ensureFreshToken()` updates only the target account credentials on disk instead of rewriting the full in-memory account array
- sync durable fields like `status` and `plan` from disk into proxy memory so later proxy writes do not resurrect stale `PRO` state after an account was already persisted as `exhausted/free`
- add a regression test proving token refresh preserves fresher `exhausted/free` disk state while still updating credentials

Closes #21

## Test plan
- [x] Added regression test: `ensureFreshToken preserves fresher exhausted/free state on disk while updating credentials`
- [x] `npm test` still shows the same pre-existing failures already present on `main`: `tests/account-pool.test.js` (`auto mode picks account with most 5h tokens remaining`, `updateRateLimit updates account in memory`) and `tests/usage-tracker.test.js`
- [ ] Manual: on a deployed instance, trigger the revoked/downgraded OAuth-account path again and confirm the card stays greyed out and shows `FREE` after refresh
