### PR TITLE
feat(proxy): distribute auto-mode terminals across accounts

### DIFF
--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -153,9 +153,20 @@ app.post('/api/terminals', async (req, res) => {
     const accounts = await configStore.readAccounts();
     const available = accounts.filter(a => a.status !== 'exhausted');
     if (available.length) {
-      available.sort((a, b) =>
-        (a.rateLimit?.window5h?.utilization ?? 0) - (b.rateLimit?.window5h?.utilization ?? 0)
-      );
+      const autoTerminalCount = (accId) =>
+        terminals.filter(t => t.mode === 'auto' && t.accountId === accId).length;
+      available.sort((a, b) => {
+        const tA = autoTerminalCount(a.id);
+        const tB = autoTerminalCount(b.id);
+        if (tA !== tB) return tA - tB;
+        const uA = a.rateLimit?.window5h?.utilization ?? 0;
+        const uB = b.rateLimit?.window5h?.utilization ?? 0;
+        if (uA !== uB) return uA - uB;
+        const wA = a.rateLimit?.weekly?.utilization ?? 0;
+        const wB = b.rateLimit?.weekly?.utilization ?? 0;
+        if (wA !== wB) return wA - wB;
+        return (a.addedAt ?? 0) - (b.addedAt ?? 0);
+      });
       accountId = available[0].id;
     }
   }

--- a/src/proxy/account-pool.js
+++ b/src/proxy/account-pool.js
@@ -6,6 +6,7 @@ import { configStore } from '../shared/config.js';
 
 export class AccountPool {
   #accounts = [];
+  #terminals = [];
   #circuitBreakers = new Map(); // accountId → CircuitBreaker
   #rateQueues = new Map();       // accountId → RateQueue
   #configStore;
@@ -39,6 +40,10 @@ export class AccountPool {
 
   getAccount(id) {
     return this.#accounts.find(a => a.id === id);
+  }
+
+  setTerminals(terminals) {
+    this.#terminals = terminals;
   }
 
   /**
@@ -222,10 +227,18 @@ export class AccountPool {
   }
 
   #leastUtilized(accounts) {
+    const autoTerminalCount = (accId) =>
+      this.#terminals.filter(t => t.mode === 'auto' && t.accountId === accId).length;
     return [...accounts].sort((a, b) => {
+      const tA = autoTerminalCount(a.id);
+      const tB = autoTerminalCount(b.id);
+      if (tA !== tB) return tA - tB;
       const uA = a.rateLimit?.window5h?.utilization ?? 0;
       const uB = b.rateLimit?.window5h?.utilization ?? 0;
       if (uA !== uB) return uA - uB;
+      const wA = a.rateLimit?.weekly?.utilization ?? 0;
+      const wB = b.rateLimit?.weekly?.utilization ?? 0;
+      if (wA !== wB) return wA - wB;
       return a.addedAt - b.addedAt;
     })[0];
   }

--- a/src/proxy/index.js
+++ b/src/proxy/index.js
@@ -23,15 +23,18 @@ let terminals = [];
 async function loadConfig() {
   await pool.load();
   terminals = await configStore.readTerminals();
+  pool.setTerminals(terminals);
   // Hot-reload terminals on file change (after initial load)
   try {
     watch(configStore.terminalsPath, { persistent: false }, async () => {
       terminals = await configStore.readTerminals().catch(() => terminals);
+      pool.setTerminals(terminals);
     });
   } catch { /* terminals.json not yet created */ }
   // Polling fallback for WSL2 where fs.watch is unreliable
   setInterval(async () => {
     terminals = await configStore.readTerminals().catch(() => terminals);
+    pool.setTerminals(terminals);
   }, 5000).unref();
 }
 

--- a/tests/account-pool.test.js
+++ b/tests/account-pool.test.js
@@ -185,6 +185,53 @@ test('markUnauthorized for unknown id is a no-op (does not throw)', async () => 
   assert.equal(pool.getAccount('acc_1').status, 'idle');
 });
 
+test('auto mode distributes terminals across accounts when utilization is equal', () => {
+  const pool = new AccountPool({
+    accounts: [
+      makeAccount('acc_1', { utilization: 0 }),
+      makeAccount('acc_2', { utilization: 0 }),
+      makeAccount('acc_3', { utilization: 0 }),
+    ],
+    terminals: [],
+  });
+  pool.setTerminals([
+    makeTerminal('sk-1', 'auto', 'acc_1'),
+    makeTerminal('sk-2', 'auto', 'acc_1'),
+  ]);
+  const acc = pool.selectAccount(makeTerminal('sk-new', 'auto', null));
+  assert.notEqual(acc.id, 'acc_1', 'should pick an account with fewer terminals');
+});
+
+test('auto mode prefers fewer terminals over lower utilization', () => {
+  const pool = new AccountPool({
+    accounts: [
+      makeAccount('acc_busy', { utilization: 0.1 }),
+      makeAccount('acc_free', { utilization: 0.3 }),
+    ],
+    terminals: [],
+  });
+  pool.setTerminals([
+    makeTerminal('sk-1', 'auto', 'acc_busy'),
+    makeTerminal('sk-2', 'auto', 'acc_busy'),
+    makeTerminal('sk-3', 'auto', 'acc_busy'),
+  ]);
+  const acc = pool.selectAccount(makeTerminal('sk-new', 'auto', null));
+  assert.equal(acc.id, 'acc_free');
+});
+
+test('auto mode uses weekly utilization as tiebreaker', () => {
+  const pool = new AccountPool({
+    accounts: [
+      makeAccount('acc_wk_high', { utilization: 0.5, weeklyUtilization: 0.8 }),
+      makeAccount('acc_wk_low', { utilization: 0.5, weeklyUtilization: 0.2 }),
+    ],
+    terminals: [],
+  });
+  pool.setTerminals([]);
+  const acc = pool.selectAccount(makeTerminal('sk-new', 'auto', null));
+  assert.equal(acc.id, 'acc_wk_low');
+});
+
 test('updateRateLimit updates account in memory', () => {
   const acc = makeAccount('acc_1');
   const pool = new AccountPool({ accounts: [acc], terminals: [] });


### PR DESCRIPTION
## Summary
- `#leastUtilized` now sorts by: auto terminal count (fewest first) → 5h utilization → weekly utilization → addedAt
- `AccountPool` gains `#terminals` field + `setTerminals()` method
- `proxy/index.js` syncs terminals to pool on load, fs.watch, and polling fallback

Closes #24

## Test plan
- [x] `auto mode distributes terminals across accounts when utilization is equal` — passes
- [x] `auto mode prefers fewer terminals over lower utilization` — passes
- [x] `auto mode uses weekly utilization as tiebreaker` — passes
- [x] Full suite: 68/71 pass (3 pre-existing failures unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)