### PR TITLE
fix(proxy): usage records not written — gzip SSE + missing close handler

### DIFF
--- a/src/proxy/forwarder.js
+++ b/src/proxy/forwarder.js
@@ -191,6 +191,7 @@ export async function forwardRequest(req, res, account, terminalId, pool, triedI
     const model = detectModel(req);
     const tapper = createUsageTapper({ accountId: account.id, terminalId, model });
     upRes.body.pipe(tapper).pipe(res);
+    res.on('close', () => { if (!tapper.destroyed) tapper.destroy(); });
     upRes.body.on('error', () => res.end());
   } else {
     const body = Buffer.from(await upRes.arrayBuffer());

--- a/src/proxy/forwarder.js
+++ b/src/proxy/forwarder.js
@@ -46,6 +46,7 @@ const HOP_BY_HOP = new Set([
   'connection', 'keep-alive', 'proxy-authenticate', 'proxy-authorization',
   'te', 'trailers', 'transfer-encoding', 'upgrade',
   'host', 'authorization', 'x-api-key', 'content-length',
+  'accept-encoding',
 ]);
 
 /**

--- a/src/proxy/usage-tracker.js
+++ b/src/proxy/usage-tracker.js
@@ -57,16 +57,21 @@ export function createUsageTapper({ accountId, terminalId, model, logsDir = DEFA
 
   const tapper = new Transform({
     async transform(chunk, _enc, cb) {
-      console.log(`[tapper] transform len=${chunk.length} accountId=${accountId}`);
       buffer += chunk.toString();
       const lines = buffer.split('\n');
       buffer = lines.pop();
+      if (lines.length > 0) console.log(`[tapper] processing ${lines.length} lines, buffer remainder=${buffer.length} chars`);
 
       for (const line of lines) {
+        if (line.startsWith('data: ')) {
+          console.log(`[tapper] data line (${line.length} chars): ${line.slice(0, 120)}`);
+        } else if (line.startsWith('event:')) {
+          console.log(`[tapper] SSE event field: ${line}`);
+        }
         if (!line.startsWith('data: ')) continue;
         try {
           const event = JSON.parse(line.slice(6));
-          console.log(`[tapper] event type=${event.type}`);
+          console.log(`[tapper] parsed event type=${event.type}`);
           if (event.type === 'message_start' && event.message?.usage) {
             inTok += event.message.usage.input_tokens ?? 0;
           }

--- a/src/proxy/usage-tracker.js
+++ b/src/proxy/usage-tracker.js
@@ -27,12 +27,14 @@ function costPerToken(model) {
  *    then writes one usage record per request to usage.jsonl.
  */
 export function createUsageTapper({ accountId, terminalId, model, logsDir = DEFAULT_LOGS_DIR }) {
+  console.log(`[tapper] created for accountId=${accountId} terminalId=${terminalId?.slice(0,20)} model=${model}`);
   let buffer = '';
   let inTok = 0;
   let outTok = 0;
   let written = false;
 
   const writeUsage = async () => {
+    console.log(`[tapper] writeUsage called: written=${written} inTok=${inTok} outTok=${outTok}`);
     if (written || (inTok === 0 && outTok === 0)) return;
     written = true;
     try {
@@ -55,6 +57,7 @@ export function createUsageTapper({ accountId, terminalId, model, logsDir = DEFA
 
   const tapper = new Transform({
     async transform(chunk, _enc, cb) {
+      console.log(`[tapper] transform len=${chunk.length} accountId=${accountId}`);
       buffer += chunk.toString();
       const lines = buffer.split('\n');
       buffer = lines.pop();
@@ -63,6 +66,7 @@ export function createUsageTapper({ accountId, terminalId, model, logsDir = DEFA
         if (!line.startsWith('data: ')) continue;
         try {
           const event = JSON.parse(line.slice(6));
+          console.log(`[tapper] event type=${event.type}`);
           if (event.type === 'message_start' && event.message?.usage) {
             inTok += event.message.usage.input_tokens ?? 0;
           }
@@ -76,12 +80,16 @@ export function createUsageTapper({ accountId, terminalId, model, logsDir = DEFA
       cb();
     },
     async flush(cb) {
+      console.log(`[tapper] flush inTok=${inTok} outTok=${outTok}`);
       await writeUsage();
       cb();
     },
   });
 
-  tapper.on('close', () => writeUsage());
+  tapper.on('close', () => {
+    console.log(`[tapper] close inTok=${inTok} outTok=${outTok} written=${written}`);
+    writeUsage();
+  });
 
   return tapper;
 }

--- a/src/proxy/usage-tracker.js
+++ b/src/proxy/usage-tracker.js
@@ -27,14 +27,12 @@ function costPerToken(model) {
  *    then writes one usage record per request to usage.jsonl.
  */
 export function createUsageTapper({ accountId, terminalId, model, logsDir = DEFAULT_LOGS_DIR }) {
-  console.log(`[tapper] created for accountId=${accountId} terminalId=${terminalId?.slice(0,20)} model=${model}`);
   let buffer = '';
   let inTok = 0;
   let outTok = 0;
   let written = false;
 
   const writeUsage = async () => {
-    console.log(`[tapper] writeUsage called: written=${written} inTok=${inTok} outTok=${outTok}`);
     if (written || (inTok === 0 && outTok === 0)) return;
     written = true;
     try {
@@ -60,16 +58,11 @@ export function createUsageTapper({ accountId, terminalId, model, logsDir = DEFA
       buffer += chunk.toString();
       const lines = buffer.split('\n');
       buffer = lines.pop();
-      if (lines.length > 0) console.log(`[tapper] processing ${lines.length} lines, buffer remainder=${buffer.length} chars`);
 
       for (const line of lines) {
-        if (lines.length <= 5 || line.startsWith('data:') || line.startsWith('event:')) {
-          console.log(`[tapper] line: ${JSON.stringify(line.slice(0, 150))}`);
-        }
         if (!line.startsWith('data: ')) continue;
         try {
           const event = JSON.parse(line.slice(6));
-          console.log(`[tapper] parsed event type=${event.type}`);
           if (event.type === 'message_start' && event.message?.usage) {
             inTok += event.message.usage.input_tokens ?? 0;
           }
@@ -83,16 +76,12 @@ export function createUsageTapper({ accountId, terminalId, model, logsDir = DEFA
       cb();
     },
     async flush(cb) {
-      console.log(`[tapper] flush inTok=${inTok} outTok=${outTok}`);
       await writeUsage();
       cb();
     },
   });
 
-  tapper.on('close', () => {
-    console.log(`[tapper] close inTok=${inTok} outTok=${outTok} written=${written}`);
-    writeUsage();
-  });
+  tapper.on('close', () => writeUsage());
 
   return tapper;
 }

--- a/src/proxy/usage-tracker.js
+++ b/src/proxy/usage-tracker.js
@@ -30,22 +30,42 @@ export function createUsageTapper({ accountId, terminalId, model, logsDir = DEFA
   let buffer = '';
   let inTok = 0;
   let outTok = 0;
+  let written = false;
+
+  const writeUsage = async () => {
+    if (written || (inTok === 0 && outTok === 0)) return;
+    written = true;
+    try {
+      const rates = costPerToken(model);
+      const usd = (inTok * rates.in + outTok * rates.out) / 1e6;
+      const record = {
+        ts: Date.now(),
+        terminalId,
+        accountId,
+        mdl: model,
+        in: inTok,
+        out: outTok,
+        usd: Math.round(usd * 1e8) / 1e8,
+      };
+      const logDir = join(logsDir, accountId);
+      await mkdir(logDir, { recursive: true });
+      await appendFile(join(logDir, 'usage.jsonl'), JSON.stringify(record) + '\n');
+    } catch { /* write failure is non-fatal */ }
+  };
 
   const tapper = new Transform({
     async transform(chunk, _enc, cb) {
       buffer += chunk.toString();
       const lines = buffer.split('\n');
-      buffer = lines.pop(); // keep incomplete last line
+      buffer = lines.pop();
 
       for (const line of lines) {
         if (!line.startsWith('data: ')) continue;
         try {
           const event = JSON.parse(line.slice(6));
-          // input tokens are in message_start
           if (event.type === 'message_start' && event.message?.usage) {
             inTok += event.message.usage.input_tokens ?? 0;
           }
-          // output tokens are in message_delta
           if (event.type === 'message_delta' && event.usage) {
             outTok += event.usage.output_tokens ?? 0;
           }
@@ -56,28 +76,12 @@ export function createUsageTapper({ accountId, terminalId, model, logsDir = DEFA
       cb();
     },
     async flush(cb) {
-      // Write usage record when stream ends
-      if (inTok > 0 || outTok > 0) {
-        try {
-          const rates = costPerToken(model);
-          const usd = (inTok * rates.in + outTok * rates.out) / 1e6;
-          const record = {
-            ts: Date.now(),
-            terminalId,
-            accountId,
-            mdl: model,
-            in: inTok,
-            out: outTok,
-            usd: Math.round(usd * 1e8) / 1e8,
-          };
-          const logDir = join(logsDir, accountId);
-          await mkdir(logDir, { recursive: true });
-          await appendFile(join(logDir, 'usage.jsonl'), JSON.stringify(record) + '\n');
-        } catch { /* write failure is non-fatal */ }
-      }
+      await writeUsage();
       cb();
     },
   });
+
+  tapper.on('close', () => writeUsage());
 
   return tapper;
 }

--- a/src/proxy/usage-tracker.js
+++ b/src/proxy/usage-tracker.js
@@ -63,10 +63,8 @@ export function createUsageTapper({ accountId, terminalId, model, logsDir = DEFA
       if (lines.length > 0) console.log(`[tapper] processing ${lines.length} lines, buffer remainder=${buffer.length} chars`);
 
       for (const line of lines) {
-        if (line.startsWith('data: ')) {
-          console.log(`[tapper] data line (${line.length} chars): ${line.slice(0, 120)}`);
-        } else if (line.startsWith('event:')) {
-          console.log(`[tapper] SSE event field: ${line}`);
+        if (lines.length <= 5 || line.startsWith('data:') || line.startsWith('event:')) {
+          console.log(`[tapper] line: ${JSON.stringify(line.slice(0, 150))}`);
         }
         if (!line.startsWith('data: ')) continue;
         try {

--- a/tests/usage-tracker.test.js
+++ b/tests/usage-tracker.test.js
@@ -11,12 +11,16 @@ let dir;
 test.before(async () => { dir = await mkdtemp(join(tmpdir(), 'hub-usage-')); });
 test.after(async () => { await rm(dir, { recursive: true }); });
 
-test('parses SSE message_delta and writes usage.jsonl', async () => {
+test('parses SSE message_start + message_delta and writes usage.jsonl', async () => {
+  const start = {
+    type: 'message_start',
+    message: { usage: { input_tokens: 100 } },
+  };
   const delta = {
     type: 'message_delta',
-    usage: { input_tokens: 100, output_tokens: 50 },
+    usage: { output_tokens: 50 },
   };
-  const sse = `data: ${JSON.stringify(delta)}\n\n`;
+  const sse = `data: ${JSON.stringify(start)}\n\ndata: ${JSON.stringify(delta)}\n\n`;
   const chunks = [];
 
   const tapper = createUsageTapper({
@@ -58,4 +62,29 @@ test('passes chunks through unchanged', async () => {
     for await (const chunk of stream) chunks.push(chunk.toString());
   });
   assert.equal(chunks.join(''), sse);
+});
+
+test('writes usage on close even if flush is not called (client disconnect)', async () => {
+  const start = { type: 'message_start', message: { usage: { input_tokens: 200 } } };
+  const delta = { type: 'message_delta', usage: { output_tokens: 80 } };
+  const sse = `data: ${JSON.stringify(start)}\n\ndata: ${JSON.stringify(delta)}\n\n`;
+
+  const tapper = createUsageTapper({
+    accountId: 'acc_3',
+    terminalId: 'sk-hub-close',
+    model: 'claude-opus-4-7',
+    logsDir: dir,
+  });
+
+  tapper.write(Buffer.from(sse));
+  tapper.destroy();
+
+  await new Promise(r => setTimeout(r, 100));
+
+  const logPath = join(dir, 'acc_3', 'usage.jsonl');
+  const lines = (await readFile(logPath, 'utf8')).trim().split('\n');
+  assert.equal(lines.length, 1);
+  const record = JSON.parse(lines[0]);
+  assert.equal(record.in, 200);
+  assert.equal(record.out, 80);
 });


### PR DESCRIPTION
## Summary

Two root causes for usage records not being written:

1. **Gzip-compressed SSE** (primary): Claude Code sends `Accept-Encoding: gzip`, which was forwarded to Anthropic. The upstream gzip-compressed SSE responses, so the usage tapper saw binary data instead of parseable `data: {...}` lines. Fix: strip `accept-encoding` from forwarded headers.

2. **Missing close handler**: `Transform.flush()` only fires on graceful `end()`, not on `destroy()` (client disconnect). Fix: extract `writeUsage()` and call from both `flush` and `close` events with a `written` guard. Also add `res.on('close', () => tapper.destroy())` in forwarder to propagate client disconnects.

Closes #26

## Test plan
- [x] `parses SSE message_start + message_delta and writes usage.jsonl` — passes
- [x] `writes usage on close even if flush is not called (client disconnect)` — new test, confirmed RED before fix
- [x] `passes chunks through unchanged` — still passes
- [x] Full suite: 70/72 pass (2 pre-existing account-pool failures)
- [x] Manual: deployed to ECS, sent request with `Accept-Encoding: gzip`, verified usage.jsonl gets new record with correct in/out token counts