### PR TITLE
feat(accounts): 支持添加第三方中转站作为 fallback 账号

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ CLAUDE.md
 .superpowers/
 .worktrees/
 docs/
+
+# local test scripts containing secrets
+test-relay.sh

--- a/src/admin/frontend/src/App.css
+++ b/src/admin/frontend/src/App.css
@@ -85,6 +85,8 @@ body {
 .badge-max { background: #D97706; color: white; }
 .badge-free { background: #a8a29e; color: white; }
 .badge-relay { background: #0891b2; color: white; }
+.relay-map-row { display: flex; align-items: center; gap: 6px; margin-bottom: 4px; }
+.relay-map-label { width: 56px; flex-shrink: 0; color: #78716c; font-weight: 500; }
 .status-dot { width: 9px; height: 9px; border-radius: 50%; flex-shrink: 0; }
 .dot-green { background: #22c55e; }
 .dot-red { background: #ef4444; }

--- a/src/admin/frontend/src/App.css
+++ b/src/admin/frontend/src/App.css
@@ -84,6 +84,7 @@ body {
 .badge-pro { background: #E87040; color: white; }
 .badge-max { background: #D97706; color: white; }
 .badge-free { background: #a8a29e; color: white; }
+.badge-relay { background: #0891b2; color: white; }
 .status-dot { width: 9px; height: 9px; border-radius: 50%; flex-shrink: 0; }
 .dot-green { background: #22c55e; }
 .dot-red { background: #ef4444; }

--- a/src/admin/frontend/src/App.jsx
+++ b/src/admin/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import TerminalsTab from './components/TerminalsTab.jsx'
 import UsageTab from './components/UsageTab.jsx'
 import GuideTab from './components/GuideTab.jsx'
 import OAuthModal from './components/OAuthModal.jsx'
+import RelayModal from './components/RelayModal.jsx'
 import TerminalModal from './components/TerminalModal.jsx'
 import LoginPage from './components/LoginPage.jsx'
 import ConfirmEmailPage from './components/ConfirmEmailPage.jsx'
@@ -26,6 +27,7 @@ export default function App() {
   const [terminals, setTerminals] = useState([])
   const [usageRecords, setUsageRecords] = useState([])
   const [showOAuth, setShowOAuth] = useState(false)
+  const [showRelay, setShowRelay] = useState(false)
   const [showTerminalModal, setShowTerminalModal] = useState(false)
 
   const staleRoundsRef = useRef(0)
@@ -81,6 +83,7 @@ export default function App() {
   }, [session?.access_token])
 
   function handleOAuthSuccess() { setShowOAuth(false); refresh() }
+  function handleRelaySuccess() { setShowRelay(false); refresh() }
   function handleTerminalSuccess() { setShowTerminalModal(false); refresh() }
 
   async function handleSignOut() {
@@ -164,6 +167,7 @@ export default function App() {
         tab={tab}
         setTab={setTab}
         onAddAccount={() => setShowOAuth(true)}
+        onAddRelay={() => setShowRelay(true)}
         onNewTerminal={() => setShowTerminalModal(true)}
         session={session}
         isAdmin={isAdmin}
@@ -198,6 +202,10 @@ export default function App() {
 
       {showOAuth && (
         <OAuthModal onClose={() => setShowOAuth(false)} onSuccess={handleOAuthSuccess} />
+      )}
+
+      {showRelay && (
+        <RelayModal onClose={() => setShowRelay(false)} onSuccess={handleRelaySuccess} />
       )}
 
       {showTerminalModal && (

--- a/src/admin/frontend/src/api.js
+++ b/src/admin/frontend/src/api.js
@@ -158,6 +158,28 @@ export async function refreshAccountToken(id) {
   return apiJson(`/api/accounts/${id}/refresh-token`, { method: 'POST' })
 }
 
+export async function addRelayAccount({ nickname, baseUrl, apiKey, modelMap }) {
+  if (USE_MOCK) {
+    await delay(400)
+    const newAcc = {
+      id: 'acc_relay' + Date.now(),
+      type: 'relay',
+      nickname,
+      baseUrl,
+      modelMap: modelMap ?? {},
+      status: 'idle',
+      hasCredentials: true,
+      addedAt: Date.now(),
+    }
+    _accounts.push(newAcc)
+    return JSON.parse(JSON.stringify(newAcc))
+  }
+  return apiJson('/api/accounts/relay', {
+    method: 'POST',
+    body: JSON.stringify({ nickname, baseUrl, apiKey, modelMap }),
+  })
+}
+
 export async function syncAccountUsage(id) {
   if (USE_MOCK) {
     await delay(400)

--- a/src/admin/frontend/src/api.js
+++ b/src/admin/frontend/src/api.js
@@ -148,6 +148,19 @@ export async function renameAccount(id, nickname) {
   })
 }
 
+export async function updateRelayModelMap(id, modelMap) {
+  if (USE_MOCK) {
+    await delay()
+    const acc = _accounts.find(a => a.id === id)
+    if (acc) acc.modelMap = modelMap
+    return JSON.parse(JSON.stringify(acc))
+  }
+  return apiJson(`/api/accounts/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ modelMap }),
+  })
+}
+
 export async function refreshAccountToken(id) {
   if (USE_MOCK) {
     await delay(600)

--- a/src/admin/frontend/src/components/AccountsTab.jsx
+++ b/src/admin/frontend/src/components/AccountsTab.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { updateTerminal, forceOnline, forceOffline, deleteAccount, renameAccount, refreshAccountToken, syncAccountUsage } from '../api.js'
+import { updateTerminal, forceOnline, forceOffline, deleteAccount, renameAccount, refreshAccountToken, syncAccountUsage, updateRelayModelMap } from '../api.js'
 
 function fmtK(n) { if (!n) return '0'; return (n / 1000).toFixed(1) }
 function pct(used, limit) { if (!limit) return 0; return Math.min(100, Math.round(used / limit * 100)) }
@@ -21,6 +21,94 @@ function fmtReset(ts) {
   const m = Math.floor((diff % 3600000) / 60000)
   if (d > 0) return `${d}d ${h}h ${m}m 后重置`
   return h > 0 ? `${h}h ${m}m 后重置` : `${m}m 后重置`
+}
+
+// Relay card body with inline-editable model mapping
+function RelayCardBody({ acc, mounted, terms, isAdmin, onRefresh }) {
+  const [editing, setEditing] = useState(false)
+  const [mapOpus, setMapOpus] = useState(acc.modelMap?.opus ?? '')
+  const [mapSonnet, setMapSonnet] = useState(acc.modelMap?.sonnet ?? '')
+  const [mapHaiku, setMapHaiku] = useState(acc.modelMap?.haiku ?? '')
+  const [saving, setSaving] = useState(false)
+
+  function startEdit(e) {
+    e.stopPropagation()
+    setMapOpus(acc.modelMap?.opus ?? '')
+    setMapSonnet(acc.modelMap?.sonnet ?? '')
+    setMapHaiku(acc.modelMap?.haiku ?? '')
+    setEditing(true)
+  }
+
+  async function save(e) {
+    e.stopPropagation()
+    setSaving(true)
+    try {
+      const modelMap = {}
+      if (mapOpus.trim()) modelMap.opus = mapOpus.trim()
+      if (mapSonnet.trim()) modelMap.sonnet = mapSonnet.trim()
+      if (mapHaiku.trim()) modelMap.haiku = mapHaiku.trim()
+      await updateRelayModelMap(acc.id, modelMap)
+      setEditing(false)
+      await onRefresh()
+    } finally { setSaving(false) }
+  }
+
+  const hasMap = acc.modelMap && Object.keys(acc.modelMap).length > 0
+
+  return (
+    <>
+      <div className="card-body" onClick={e => editing && e.stopPropagation()}>
+        {mounted && <div className="mounted-label">✓ 已挂载</div>}
+        {editing ? (
+          <div className="relay-map-edit" style={{ fontSize: 12 }}>
+            <div className="relay-map-row">
+              <span className="relay-map-label">Opus →</span>
+              <input className="inline-edit" value={mapOpus} onChange={e => setMapOpus(e.target.value)}
+                placeholder="留空则透传" style={{ flex: 1 }} />
+            </div>
+            <div className="relay-map-row">
+              <span className="relay-map-label">Sonnet →</span>
+              <input className="inline-edit" value={mapSonnet} onChange={e => setMapSonnet(e.target.value)}
+                placeholder="留空则透传" style={{ flex: 1 }} />
+            </div>
+            <div className="relay-map-row">
+              <span className="relay-map-label">Haiku →</span>
+              <input className="inline-edit" value={mapHaiku} onChange={e => setMapHaiku(e.target.value)}
+                placeholder="留空则透传" style={{ flex: 1 }} />
+            </div>
+            <div style={{ display: 'flex', gap: 6, marginTop: 6 }}>
+              <button className="btn btn-primary btn-sm" onClick={save} disabled={saving}>
+                {saving ? '…' : '保存'}
+              </button>
+              <button className="btn btn-ghost btn-sm" onClick={e => { e.stopPropagation(); setEditing(false) }}>取消</button>
+            </div>
+          </div>
+        ) : (
+          <>
+            {hasMap ? (
+              <div className="relay-modelmap" style={{ fontSize: 12, color: '#57534e', lineHeight: 1.6 }}>
+                {acc.modelMap.opus && <div>Opus → <code>{acc.modelMap.opus}</code></div>}
+                {acc.modelMap.sonnet && <div>Sonnet → <code>{acc.modelMap.sonnet}</code></div>}
+                {acc.modelMap.haiku && <div>Haiku → <code>{acc.modelMap.haiku}</code></div>}
+              </div>
+            ) : (
+              <div style={{ fontSize: 12, color: '#a8a29e' }}>无模型映射 · 原样透传</div>
+            )}
+            {isAdmin && (
+              <button className="btn btn-ghost btn-sm" style={{ marginTop: 6, fontSize: 11 }} onClick={startEdit}>
+                编辑映射
+              </button>
+            )}
+          </>
+        )}
+      </div>
+      {terms.length > 0 && (
+        <div className="card-footer">
+          {terms.map(t => <span key={t.id} className="footer-chip">{t.name}</span>)}
+        </div>
+      )}
+    </>
+  )
 }
 
 // Per-card action panel (shown in a popover-style expanded section)
@@ -367,31 +455,7 @@ export default function AccountsTab({ accounts, terminals, onRefresh, onNewTermi
                   onClose={() => setExpandedCard(null)}
                 />
               ) : isRelay ? (
-                <>
-                  <div className="card-body">
-                    {mounted && <div className="mounted-label">✓ 已挂载</div>}
-                    <div className="relay-meta" style={{ fontSize: 12, color: '#78716c', wordBreak: 'break-all', marginBottom: 6 }}>
-                      {acc.baseUrl}
-                    </div>
-                    {acc.modelMap && Object.keys(acc.modelMap).length > 0 ? (
-                      <div className="relay-modelmap" style={{ fontSize: 12, color: '#57534e', lineHeight: 1.6 }}>
-                        {acc.modelMap.opus && <div>Opus → <code>{acc.modelMap.opus}</code></div>}
-                        {acc.modelMap.sonnet && <div>Sonnet → <code>{acc.modelMap.sonnet}</code></div>}
-                        {acc.modelMap.haiku && <div>Haiku → <code>{acc.modelMap.haiku}</code></div>}
-                      </div>
-                    ) : (
-                      <div style={{ fontSize: 12, color: '#a8a29e' }}>无模型映射 · 原样透传</div>
-                    )}
-                    <div style={{ fontSize: 11, color: '#a8a29e', marginTop: 8 }}>
-                      仅在所有 OAuth 账号耗尽时作为 fallback
-                    </div>
-                  </div>
-                  {terms.length > 0 && (
-                    <div className="card-footer">
-                      {terms.map(t => <span key={t.id} className="footer-chip">{t.name}</span>)}
-                    </div>
-                  )}
-                </>
+                <RelayCardBody acc={acc} mounted={mounted} terms={terms} isAdmin={isAdmin} onRefresh={onRefresh} />
               ) : (
                 <>
                   <div className="card-body">

--- a/src/admin/frontend/src/components/AccountsTab.jsx
+++ b/src/admin/frontend/src/components/AccountsTab.jsx
@@ -74,10 +74,12 @@ function AccountActions({ acc, onAction, onClose }) {
         </button>
       )}
 
-      {/* Refresh token */}
-      <button className="action-btn" disabled={busy === 'refresh'} onClick={() => run('refresh')}>
-        {busy === 'refresh' ? '…' : '🔑 刷新 Token'}
-      </button>
+      {/* Refresh token — OAuth only */}
+      {acc.type !== 'relay' && (
+        <button className="action-btn" disabled={busy === 'refresh'} onClick={() => run('refresh')}>
+          {busy === 'refresh' ? '…' : '🔑 刷新 Token'}
+        </button>
+      )}
 
       {/* Delete */}
       <button className="action-btn action-btn-danger" disabled={busy === 'delete'} onClick={() => run('delete')}>
@@ -305,7 +307,8 @@ export default function AccountsTab({ accounts, terminals, onRefresh, onNewTermi
           const terms = terminalsOnAccount(acc.id)
           const actionsOpen = expandedCard === acc.id
           const displayName = acc.nickname || acc.email
-          const expiry = fmtExpiry(acc.tokenExpiresAt)
+          const isRelay = acc.type === 'relay'
+          const expiry = !isRelay && fmtExpiry(acc.tokenExpiresAt)
           const reset5h = fmtReset(acc.rateLimit?.window5h?.resetAt)
           const resetWeek = fmtReset(acc.rateLimit?.weekly?.resetAt)
 
@@ -316,29 +319,35 @@ export default function AccountsTab({ accounts, terminals, onRefresh, onNewTermi
               onClick={() => !actionsOpen && mountAccount(acc)}
             >
               <div className={`card-header ${exhausted ? 'exhausted' : ''}`}>
-                <span className="card-email" title={acc.email}>{displayName}</span>
-                <span className={`plan-badge ${acc.plan === 'max' ? 'badge-max' : acc.plan === 'free' ? 'badge-free' : 'badge-pro'}`}>
-                  {acc.plan?.toUpperCase() ?? 'PRO'}
-                </span>
+                <span className="card-email" title={acc.email || acc.baseUrl}>{displayName}</span>
+                {isRelay ? (
+                  <span className="plan-badge badge-relay">中转</span>
+                ) : (
+                  <span className={`plan-badge ${acc.plan === 'max' ? 'badge-max' : acc.plan === 'free' ? 'badge-free' : 'badge-pro'}`}>
+                    {acc.plan?.toUpperCase() ?? 'PRO'}
+                  </span>
+                )}
                 <span className={`status-dot ${statusDot(acc)}`} />
                 {isAdmin && (
                   <>
-                    {/* Sync usage button */}
-                    <button
-                      className={`card-refresh-btn${syncingId === acc.id ? ' spinning' : ''}`}
-                      title="同步用量"
-                      onClick={async e => {
-                        e.stopPropagation()
-                        setSyncingId(acc.id)
-                        try {
-                          const updated = await syncAccountUsage(acc.id)
-                          await onRefresh()
-                        } finally { setSyncingId(null) }
-                      }}
-                      disabled={syncingId === acc.id}
-                    >
-                      ↻
-                    </button>
+                    {/* Sync usage button — hidden for relay (no Anthropic rate-limit headers) */}
+                    {!isRelay && (
+                      <button
+                        className={`card-refresh-btn${syncingId === acc.id ? ' spinning' : ''}`}
+                        title="同步用量"
+                        onClick={async e => {
+                          e.stopPropagation()
+                          setSyncingId(acc.id)
+                          try {
+                            const updated = await syncAccountUsage(acc.id)
+                            await onRefresh()
+                          } finally { setSyncingId(null) }
+                        }}
+                        disabled={syncingId === acc.id}
+                      >
+                        ↻
+                      </button>
+                    )}
                     {/* Edit toggle button */}
                     <button
                       className="card-edit-btn"
@@ -357,6 +366,32 @@ export default function AccountsTab({ accounts, terminals, onRefresh, onNewTermi
                   onAction={action => handleCardAction(acc, action)}
                   onClose={() => setExpandedCard(null)}
                 />
+              ) : isRelay ? (
+                <>
+                  <div className="card-body">
+                    {mounted && <div className="mounted-label">✓ 已挂载</div>}
+                    <div className="relay-meta" style={{ fontSize: 12, color: '#78716c', wordBreak: 'break-all', marginBottom: 6 }}>
+                      {acc.baseUrl}
+                    </div>
+                    {acc.modelMap && Object.keys(acc.modelMap).length > 0 ? (
+                      <div className="relay-modelmap" style={{ fontSize: 12, color: '#57534e', lineHeight: 1.6 }}>
+                        {acc.modelMap.opus && <div>Opus → <code>{acc.modelMap.opus}</code></div>}
+                        {acc.modelMap.sonnet && <div>Sonnet → <code>{acc.modelMap.sonnet}</code></div>}
+                        {acc.modelMap.haiku && <div>Haiku → <code>{acc.modelMap.haiku}</code></div>}
+                      </div>
+                    ) : (
+                      <div style={{ fontSize: 12, color: '#a8a29e' }}>无模型映射 · 原样透传</div>
+                    )}
+                    <div style={{ fontSize: 11, color: '#a8a29e', marginTop: 8 }}>
+                      仅在所有 OAuth 账号耗尽时作为 fallback
+                    </div>
+                  </div>
+                  {terms.length > 0 && (
+                    <div className="card-footer">
+                      {terms.map(t => <span key={t.id} className="footer-chip">{t.name}</span>)}
+                    </div>
+                  )}
+                </>
               ) : (
                 <>
                   <div className="card-body">

--- a/src/admin/frontend/src/components/AccountsTab.jsx
+++ b/src/admin/frontend/src/components/AccountsTab.jsx
@@ -24,82 +24,21 @@ function fmtReset(ts) {
 }
 
 // Relay card body with inline-editable model mapping
-function RelayCardBody({ acc, mounted, terms, isAdmin, onRefresh }) {
-  const [editing, setEditing] = useState(false)
-  const [mapOpus, setMapOpus] = useState(acc.modelMap?.opus ?? '')
-  const [mapSonnet, setMapSonnet] = useState(acc.modelMap?.sonnet ?? '')
-  const [mapHaiku, setMapHaiku] = useState(acc.modelMap?.haiku ?? '')
-  const [saving, setSaving] = useState(false)
-
-  function startEdit(e) {
-    e.stopPropagation()
-    setMapOpus(acc.modelMap?.opus ?? '')
-    setMapSonnet(acc.modelMap?.sonnet ?? '')
-    setMapHaiku(acc.modelMap?.haiku ?? '')
-    setEditing(true)
-  }
-
-  async function save(e) {
-    e.stopPropagation()
-    setSaving(true)
-    try {
-      const modelMap = {}
-      if (mapOpus.trim()) modelMap.opus = mapOpus.trim()
-      if (mapSonnet.trim()) modelMap.sonnet = mapSonnet.trim()
-      if (mapHaiku.trim()) modelMap.haiku = mapHaiku.trim()
-      await updateRelayModelMap(acc.id, modelMap)
-      setEditing(false)
-      await onRefresh()
-    } finally { setSaving(false) }
-  }
-
+function RelayCardBody({ acc, mounted, terms }) {
   const hasMap = acc.modelMap && Object.keys(acc.modelMap).length > 0
 
   return (
     <>
-      <div className="card-body" onClick={e => editing && e.stopPropagation()}>
+      <div className="card-body">
         {mounted && <div className="mounted-label">✓ 已挂载</div>}
-        {editing ? (
-          <div className="relay-map-edit" style={{ fontSize: 12 }}>
-            <div className="relay-map-row">
-              <span className="relay-map-label">Opus →</span>
-              <input className="inline-edit" value={mapOpus} onChange={e => setMapOpus(e.target.value)}
-                placeholder="留空则透传" style={{ flex: 1 }} />
-            </div>
-            <div className="relay-map-row">
-              <span className="relay-map-label">Sonnet →</span>
-              <input className="inline-edit" value={mapSonnet} onChange={e => setMapSonnet(e.target.value)}
-                placeholder="留空则透传" style={{ flex: 1 }} />
-            </div>
-            <div className="relay-map-row">
-              <span className="relay-map-label">Haiku →</span>
-              <input className="inline-edit" value={mapHaiku} onChange={e => setMapHaiku(e.target.value)}
-                placeholder="留空则透传" style={{ flex: 1 }} />
-            </div>
-            <div style={{ display: 'flex', gap: 6, marginTop: 6 }}>
-              <button className="btn btn-primary btn-sm" onClick={save} disabled={saving}>
-                {saving ? '…' : '保存'}
-              </button>
-              <button className="btn btn-ghost btn-sm" onClick={e => { e.stopPropagation(); setEditing(false) }}>取消</button>
-            </div>
+        {hasMap ? (
+          <div className="relay-modelmap" style={{ fontSize: 12, color: '#57534e', lineHeight: 1.6 }}>
+            {acc.modelMap.opus && <div>Opus → <code>{acc.modelMap.opus}</code></div>}
+            {acc.modelMap.sonnet && <div>Sonnet → <code>{acc.modelMap.sonnet}</code></div>}
+            {acc.modelMap.haiku && <div>Haiku → <code>{acc.modelMap.haiku}</code></div>}
           </div>
         ) : (
-          <>
-            {hasMap ? (
-              <div className="relay-modelmap" style={{ fontSize: 12, color: '#57534e', lineHeight: 1.6 }}>
-                {acc.modelMap.opus && <div>Opus → <code>{acc.modelMap.opus}</code></div>}
-                {acc.modelMap.sonnet && <div>Sonnet → <code>{acc.modelMap.sonnet}</code></div>}
-                {acc.modelMap.haiku && <div>Haiku → <code>{acc.modelMap.haiku}</code></div>}
-              </div>
-            ) : (
-              <div style={{ fontSize: 12, color: '#a8a29e' }}>无模型映射 · 原样透传</div>
-            )}
-            {isAdmin && (
-              <button className="btn btn-ghost btn-sm" style={{ marginTop: 6, fontSize: 11 }} onClick={startEdit}>
-                编辑映射
-              </button>
-            )}
-          </>
+          <div style={{ fontSize: 12, color: '#a8a29e' }}>无模型映射 · 原样透传</div>
         )}
       </div>
       {terms.length > 0 && (
@@ -116,10 +55,24 @@ function AccountActions({ acc, onAction, onClose }) {
   const [renaming, setRenaming] = useState(false)
   const [newName, setNewName] = useState(acc.nickname || acc.email)
   const [busy, setBusy] = useState(null)
+  const [editingMap, setEditingMap] = useState(false)
+  const [mapOpus, setMapOpus] = useState(acc.modelMap?.opus ?? '')
+  const [mapSonnet, setMapSonnet] = useState(acc.modelMap?.sonnet ?? '')
+  const [mapHaiku, setMapHaiku] = useState(acc.modelMap?.haiku ?? '')
 
   async function run(action) {
     setBusy(action)
     try { await onAction(action) } finally { setBusy(null) }
+  }
+
+  async function saveModelMap() {
+    const modelMap = {}
+    if (mapOpus.trim()) modelMap.opus = mapOpus.trim()
+    if (mapSonnet.trim()) modelMap.sonnet = mapSonnet.trim()
+    if (mapHaiku.trim()) modelMap.haiku = mapHaiku.trim()
+    setBusy('modelmap')
+    try { await onAction('modelmap:' + JSON.stringify(modelMap)) } finally { setBusy(null) }
+    setEditingMap(false)
   }
 
   const exhausted = acc.status === 'exhausted'
@@ -149,6 +102,44 @@ function AccountActions({ acc, onAction, onClose }) {
         <button className="action-btn" onClick={() => { setNewName(acc.nickname || acc.email); setRenaming(true) }}>
           ✏️ 重命名
         </button>
+      )}
+
+      {/* Model map editing — relay only */}
+      {acc.type === 'relay' && (
+        editingMap ? (
+          <div className="relay-map-edit" style={{ fontSize: 12, padding: '4px 0' }}>
+            <div className="relay-map-row">
+              <span className="relay-map-label">Opus →</span>
+              <input className="inline-edit" value={mapOpus} onChange={e => setMapOpus(e.target.value)}
+                placeholder="留空则透传" style={{ flex: 1 }} />
+            </div>
+            <div className="relay-map-row">
+              <span className="relay-map-label">Sonnet →</span>
+              <input className="inline-edit" value={mapSonnet} onChange={e => setMapSonnet(e.target.value)}
+                placeholder="留空则透传" style={{ flex: 1 }} />
+            </div>
+            <div className="relay-map-row">
+              <span className="relay-map-label">Haiku →</span>
+              <input className="inline-edit" value={mapHaiku} onChange={e => setMapHaiku(e.target.value)}
+                placeholder="留空则透传" style={{ flex: 1 }} />
+            </div>
+            <div style={{ display: 'flex', gap: 6, marginTop: 6 }}>
+              <button className="btn btn-primary btn-sm" onClick={saveModelMap} disabled={busy === 'modelmap'}>
+                {busy === 'modelmap' ? '…' : '保存'}
+              </button>
+              <button className="btn btn-ghost btn-sm" onClick={() => setEditingMap(false)}>取消</button>
+            </div>
+          </div>
+        ) : (
+          <button className="action-btn" onClick={() => {
+            setMapOpus(acc.modelMap?.opus ?? '')
+            setMapSonnet(acc.modelMap?.sonnet ?? '')
+            setMapHaiku(acc.modelMap?.haiku ?? '')
+            setEditingMap(true)
+          }}>
+            🔀 编辑模型映射
+          </button>
+        )
       )}
 
       {/* Online / Offline toggle */}
@@ -291,6 +282,8 @@ export default function AccountsTab({ accounts, terminals, onRefresh, onNewTermi
       setExpandedCard(null)
     } else if (action.startsWith('rename:')) {
       await renameAccount(acc.id, action.slice(7))
+    } else if (action.startsWith('modelmap:')) {
+      await updateRelayModelMap(acc.id, JSON.parse(action.slice(9)))
     }
     await onRefresh()
   }
@@ -455,7 +448,7 @@ export default function AccountsTab({ accounts, terminals, onRefresh, onNewTermi
                   onClose={() => setExpandedCard(null)}
                 />
               ) : isRelay ? (
-                <RelayCardBody acc={acc} mounted={mounted} terms={terms} isAdmin={isAdmin} onRefresh={onRefresh} />
+                <RelayCardBody acc={acc} mounted={mounted} terms={terms} />
               ) : (
                 <>
                   <div className="card-body">

--- a/src/admin/frontend/src/components/Nav.jsx
+++ b/src/admin/frontend/src/components/Nav.jsx
@@ -1,6 +1,6 @@
 import LogoMark from './LogoMark.jsx'
 
-export default function Nav({ tab, setTab, onAddAccount, onNewTerminal, session, isAdmin, onSignOut }) {
+export default function Nav({ tab, setTab, onAddAccount, onAddRelay, onNewTerminal, session, isAdmin, onSignOut }) {
   return (
     <nav className="nav">
       <div className="nav-logo"><LogoMark size={20} />claudecode-hub</div>
@@ -13,7 +13,10 @@ export default function Nav({ tab, setTab, onAddAccount, onNewTerminal, session,
           <button className="btn btn-primary" onClick={onNewTerminal}>+ 新建终端</button>
         )}
         {tab === 'accounts' && isAdmin && (
-          <button className="btn btn-primary" onClick={onAddAccount}>+ 添加账号</button>
+          <>
+            <button className="btn btn-ghost" onClick={onAddRelay}>+ 添加中转</button>
+            <button className="btn btn-primary" onClick={onAddAccount}>+ 添加账号</button>
+          </>
         )}
         <div className="nav-user">
           <span className="nav-user-email">{session?.user?.email}</span>

--- a/src/admin/frontend/src/components/RelayModal.jsx
+++ b/src/admin/frontend/src/components/RelayModal.jsx
@@ -1,0 +1,105 @@
+import { useState } from 'react'
+import { addRelayAccount } from '../api.js'
+
+/**
+ * Add a third-party relay station as a fallback account.
+ * Relays use a static x-api-key and don't return Anthropic rate-limit headers,
+ * so they only serve requests when all OAuth accounts are cooling/exhausted.
+ * Optional model-name remapping per tier handles relays that only expose
+ * older model IDs (e.g. opus-4-6 instead of opus-4-7).
+ */
+export default function RelayModal({ onClose, onSuccess }) {
+  const [nickname, setNickname] = useState('')
+  const [baseUrl, setBaseUrl] = useState('')
+  const [apiKey, setApiKey] = useState('')
+  const [mapOpus, setMapOpus] = useState('')
+  const [mapSonnet, setMapSonnet] = useState('')
+  const [mapHaiku, setMapHaiku] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    if (!nickname.trim()) return setError('请填写昵称')
+    if (!/^https:\/\//i.test(baseUrl.trim())) return setError('Base URL 必须以 https:// 开头')
+    if (!apiKey.trim()) return setError('请填写 API Key')
+
+    const modelMap = {}
+    if (mapOpus.trim()) modelMap.opus = mapOpus.trim()
+    if (mapSonnet.trim()) modelMap.sonnet = mapSonnet.trim()
+    if (mapHaiku.trim()) modelMap.haiku = mapHaiku.trim()
+
+    setLoading(true)
+    setError('')
+    try {
+      const acc = await addRelayAccount({
+        nickname: nickname.trim(),
+        baseUrl: baseUrl.trim(),
+        apiKey: apiKey.trim(),
+        modelMap,
+      })
+      onSuccess(acc)
+    } catch (err) {
+      setError(err.message || '添加失败')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="modal-backdrop" onClick={e => e.target === e.currentTarget && onClose()}>
+      <div className="modal">
+        <div className="modal-title">添加中转站</div>
+        <div className="modal-subtitle" style={{ color: '#78716c', fontSize: 13, marginBottom: 16, lineHeight: 1.5 }}>
+          中转账号仅在所有 OAuth 账号全部耗尽时作为 fallback 使用。
+          若中转站仅支持特定模型名，可在下方三档填写目标模型名覆盖请求。
+        </div>
+        <form onSubmit={handleSubmit}>
+          <div className="form-row">
+            <label className="form-label">昵称</label>
+            <input className="form-input" value={nickname} onChange={e => setNickname(e.target.value)}
+              placeholder="例如：青云TOP" autoFocus />
+          </div>
+          <div className="form-row">
+            <label className="form-label">Base URL</label>
+            <input className="form-input" value={baseUrl} onChange={e => setBaseUrl(e.target.value)}
+              placeholder="https://api.example.com" />
+          </div>
+          <div className="form-row">
+            <label className="form-label">API Key</label>
+            <input className="form-input" type="password" value={apiKey} onChange={e => setApiKey(e.target.value)}
+              placeholder="sk-xxx" autoComplete="off" />
+          </div>
+
+          <div style={{ margin: '16px 0 8px', fontSize: 13, fontWeight: 600, color: '#44403c' }}>
+            模型映射 <span style={{ fontWeight: 400, color: '#a8a29e' }}>（留空则透传）</span>
+          </div>
+          <div className="form-row">
+            <label className="form-label">Opus 档 →</label>
+            <input className="form-input" value={mapOpus} onChange={e => setMapOpus(e.target.value)}
+              placeholder="留空 / 或 claude-opus-4-5-20250929" />
+          </div>
+          <div className="form-row">
+            <label className="form-label">Sonnet 档 →</label>
+            <input className="form-input" value={mapSonnet} onChange={e => setMapSonnet(e.target.value)}
+              placeholder="留空 / 或 claude-sonnet-4-20250514" />
+          </div>
+          <div className="form-row">
+            <label className="form-label">Haiku 档 →</label>
+            <input className="form-input" value={mapHaiku} onChange={e => setMapHaiku(e.target.value)}
+              placeholder="留空 / 或 claude-haiku-4-5-20251001" />
+          </div>
+
+          {error && <div className="modal-error">{error}</div>}
+
+          <div className="modal-actions">
+            <button type="button" className="btn btn-ghost" onClick={onClose} disabled={loading}>取消</button>
+            <button type="submit" className="btn btn-primary" disabled={loading}>
+              {loading ? '添加中…' : '添加'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/src/admin/frontend/src/components/UsageTab.jsx
+++ b/src/admin/frontend/src/components/UsageTab.jsx
@@ -145,16 +145,24 @@ export default function UsageTab({ accounts, terminals }) {
   const yEnd = new Date(); yEnd.setHours(0, 0, 0, 0)
   const yesterdayUsd = records.filter(r => r.ts >= yStart.getTime() && r.ts < yEnd.getTime()).reduce((s, r) => s + (r.usd ?? 0), 0)
 
-  const groupKey = r => group === 'account' ? r.accountId : r.terminalId
+  const DELETED_ACCOUNT = '__deleted_account__'
+  const DELETED_TERMINAL = '__deleted_terminal__'
+  const groupKey = r => {
+    if (group === 'account') {
+      const exists = accounts.some(a => a.id === r.accountId)
+      return exists ? r.accountId : DELETED_ACCOUNT
+    }
+    const exists = terminals.some(t => t.id === r.terminalId)
+    return exists ? r.terminalId : DELETED_TERMINAL
+  }
   const labelFor = id => {
+    if (id === DELETED_ACCOUNT) return '已删除账号'
+    if (id === DELETED_TERMINAL) return '已删除终端'
     if (group === 'account') {
       const acc = accounts.find(a => a.id === id)
-      if (acc) return acc.nickname || acc.email || id
-      return `已删除账号 (${id.slice(-4)})`
+      return acc?.nickname || acc?.email || id
     }
-    const t = terminals.find(t => t.id === id)
-    if (t) return t.name || id
-    return `已删除终端 (${id.slice(-4)})`
+    return terminals.find(t => t.id === id)?.name || id
   }
 
   const dailyData = useMemo(() => {

--- a/src/admin/frontend/src/components/UsageTab.jsx
+++ b/src/admin/frontend/src/components/UsageTab.jsx
@@ -147,8 +147,14 @@ export default function UsageTab({ accounts, terminals }) {
 
   const groupKey = r => group === 'account' ? r.accountId : r.terminalId
   const labelFor = id => {
-    if (group === 'account') return accounts.find(a => a.id === id)?.email ?? id
-    return terminals.find(t => t.id === id)?.name ?? id
+    if (group === 'account') {
+      const acc = accounts.find(a => a.id === id)
+      if (acc) return acc.nickname || acc.email || id
+      return `已删除账号 (${id.slice(-4)})`
+    }
+    const t = terminals.find(t => t.id === id)
+    if (t) return t.name || id
+    return `已删除终端 (${id.slice(-4)})`
   }
 
   const dailyData = useMemo(() => {

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -90,6 +90,16 @@ app.patch('/api/accounts/:id', requireAdmin, async (req, res) => {
   const acc = accounts.find(a => a.id === req.params.id);
   if (!acc) return res.status(404).json({ error: 'not_found' });
   if (req.body.nickname !== undefined) acc.nickname = req.body.nickname;
+  if (req.body.modelMap !== undefined && acc.type === 'relay') {
+    const normalisedMap = {};
+    if (req.body.modelMap && typeof req.body.modelMap === 'object') {
+      for (const tier of ['opus', 'sonnet', 'haiku']) {
+        const v = req.body.modelMap[tier];
+        if (typeof v === 'string' && v.trim().length > 0) normalisedMap[tier] = v.trim();
+      }
+    }
+    acc.modelMap = normalisedMap;
+  }
   await configStore.writeAccounts(accounts);
   res.json(sanitiseAccount(acc));
 });

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -43,6 +43,7 @@ app.post('/api/accounts/:id/refresh-token', requireAdmin, async (req, res) => {
   const accounts = await configStore.readAccounts();
   const acc = accounts.find(a => a.id === req.params.id);
   if (!acc) return res.status(404).json({ error: 'not_found' });
+  if (acc.type === 'relay') return res.status(400).json({ error: 'relay_no_refresh' });
   try {
     const { refreshToken } = await import('../proxy/token-manager.js');
     const { fetchMe } = await import('./oauth-login.js');
@@ -121,6 +122,44 @@ app.delete('/api/accounts/:id', requireAdmin, async (req, res) => {
   await reassignTerminals(req.params.id, remaining, null);
   await configStore.writeAccounts(remaining);
   res.json({ ok: true });
+});
+
+// Add a third-party relay-station account (static apiKey + baseUrl).
+// Relays serve Claude /v1/messages without OAuth; they're used as a fallback
+// tier when all OAuth accounts are cooling/exhausted. Optional per-tier
+// modelMap rewrites body.model before forwarding (e.g. opus-4-7 → opus-4-6).
+app.post('/api/accounts/relay', requireAdmin, async (req, res) => {
+  const { nickname, baseUrl, apiKey, modelMap } = req.body ?? {};
+  if (typeof nickname !== 'string' || nickname.trim().length === 0) {
+    return res.status(400).json({ error: 'nickname_required' });
+  }
+  if (typeof baseUrl !== 'string' || !/^https:\/\//i.test(baseUrl)) {
+    return res.status(400).json({ error: 'invalid_base_url', message: 'baseUrl must start with https://' });
+  }
+  if (typeof apiKey !== 'string' || apiKey.trim().length === 0) {
+    return res.status(400).json({ error: 'api_key_required' });
+  }
+  const normalisedMap = {};
+  if (modelMap && typeof modelMap === 'object') {
+    for (const tier of ['opus', 'sonnet', 'haiku']) {
+      const v = modelMap[tier];
+      if (typeof v === 'string' && v.trim().length > 0) normalisedMap[tier] = v.trim();
+    }
+  }
+  const accounts = await configStore.readAccounts();
+  const acc = {
+    id: `acc_${randomBytes(6).toString('hex')}`,
+    type: 'relay',
+    nickname: nickname.trim(),
+    baseUrl: baseUrl.replace(/\/$/, ''),
+    credentials: { apiKey: apiKey.trim() },
+    modelMap: normalisedMap,
+    status: 'idle',
+    addedAt: Date.now(),
+  };
+  accounts.push(acc);
+  await configStore.writeAccounts(accounts);
+  res.status(201).json(sanitiseAccount(acc));
 });
 
 // ── Terminals ────────────────────────────────────────────────────────────
@@ -307,6 +346,8 @@ app.post('/api/oauth/import-manual/:sessionId', requireAdmin, async (req, res) =
  * then update acc.rateLimit in-place. Non-fatal: errors are silently ignored.
  */
 async function syncRateLimit(acc) {
+  // Relay accounts have no Anthropic rate-limit headers to sync.
+  if (acc.type === 'relay') return;
   try {
     if (isExpired(acc)) {
       const update = await refreshToken(acc);
@@ -376,6 +417,12 @@ async function syncRateLimit(acc) {
 
 function sanitiseAccount(acc) {
   const { credentials, ...rest } = acc;
+  if (acc.type === 'relay') {
+    return {
+      ...rest,
+      hasCredentials: !!credentials?.apiKey,
+    };
+  }
   return {
     ...rest,
     hasCredentials: !!credentials?.accessToken,

--- a/src/proxy/account-pool.js
+++ b/src/proxy/account-pool.js
@@ -72,16 +72,22 @@ export class AccountPool {
    * Pick the least-used account excluding the given set of account IDs.
    * Prefers warm (non-cooling) accounts; falls back to cooling accounts
    * (soonest resetAt first) when no warm candidate is available.
+   * Relay accounts are only considered after all OAuth accounts are excluded
+   * or unusable — they act as an absolute fallback tier.
    * Returns null if no alternative is available.
    * @param {Set<string>} excludeIds
    */
   selectFallback(excludeIds) {
-    const usable = this.#accounts
+    const isRelay = (a) => a.type === 'relay';
+    const eligible = this.#accounts
       .filter(a => !excludeIds.has(a.id) && a.status !== 'exhausted' && this.#ensureCB(a.id).canRequest());
-    const warm = usable.filter(a => !this.#isCooling(a));
+    const oauth = eligible.filter(a => !isRelay(a));
+    const warm = oauth.filter(a => !this.#isCooling(a));
     if (warm.length) return this.#leastUtilized(warm);
-    const cooling = usable.filter(a => this.#isCooling(a));
+    const cooling = oauth.filter(a => this.#isCooling(a));
     if (cooling.length) return this.#soonestReset(cooling);
+    const relays = eligible.filter(isRelay);
+    if (relays.length) return this.#oldestRelay(relays);
     return null;
   }
 
@@ -151,8 +157,10 @@ export class AccountPool {
   /**
    * Ensure accessToken is fresh; refreshes in-place if needed.
    * Returns the (possibly updated) account.
+   * Relay accounts use a static apiKey and skip refresh entirely.
    */
   async ensureFreshToken(account) {
+    if (account.type === 'relay') return account;
     if (!isExpired(account)) return account;
     const update = await refreshToken(account);
     Object.assign(account.credentials, update.credentials);
@@ -185,11 +193,14 @@ export class AccountPool {
   }
 
   #pickAuto(preferredId = null) {
-    const usable = this.#accounts
+    const isRelay = (a) => a.type === 'relay';
+    const eligible = this.#accounts
       .filter(a => a.status !== 'exhausted' && this.#ensureCB(a.id).canRequest());
-    if (usable.length === 0) throw new Error('503: no available accounts');
+    if (eligible.length === 0) throw new Error('503: no available accounts');
 
-    const warm = usable.filter(a => !this.#isCooling(a));
+    // OAuth tier first — relays are reserved as absolute fallback.
+    const oauth = eligible.filter(a => !isRelay(a));
+    const warm = oauth.filter(a => !this.#isCooling(a));
 
     // Prefer the current account only while it's warm — stickiness must not
     // pin an auto-mode terminal to a cooling account.
@@ -200,9 +211,21 @@ export class AccountPool {
 
     if (warm.length) return this.#leastUtilized(warm);
 
-    // Every usable account is cooling. Graceful degrade: try the one that
-    // resets soonest so the caller waits the least.
-    return this.#soonestReset(usable);
+    // No warm OAuth. If a relay is available, prefer it over waiting on a
+    // cooling OAuth account — relays don't have per-window limits so the
+    // caller gets served immediately.
+    const relays = eligible.filter(isRelay);
+    if (relays.length) return this.#oldestRelay(relays);
+
+    // No OAuth warm, no relay — graceful degrade to soonest-reset cooling OAuth.
+    const coolingOauth = oauth.filter(a => this.#isCooling(a));
+    if (coolingOauth.length) return this.#soonestReset(coolingOauth);
+
+    throw new Error('503: no available accounts');
+  }
+
+  #oldestRelay(relays) {
+    return [...relays].sort((a, b) => (a.addedAt ?? 0) - (b.addedAt ?? 0))[0];
   }
 
   /**

--- a/src/proxy/forwarder.js
+++ b/src/proxy/forwarder.js
@@ -3,6 +3,7 @@ import { HttpsProxyAgent } from 'https-proxy-agent';
 import { createUsageTapper } from './usage-tracker.js';
 import { isOAuthRevoked } from './permission-guard.js';
 import { applyModelMap } from './model-map.js';
+import { stripThinkingBlocks } from './thinking-strip.js';
 
 const UPSTREAM = 'https://api.anthropic.com';
 const UPSTREAM_TIMEOUT_MS = 60_000;
@@ -70,6 +71,12 @@ export async function forwardRequest(req, res, account, terminalId, pool, triedI
   }
 
   let outBody = req.method !== 'GET' && req.method !== 'HEAD' ? req.rawBody : undefined;
+
+  // Always strip thinking blocks from historical assistant messages.
+  // Signatures in these blocks are HMACed per-account; our rotating pool
+  // means a replayed block from a prior turn will fail validation at a
+  // different upstream. See @/src/proxy/thinking-strip.js for detail.
+  if (outBody) outBody = stripThinkingBlocks(outBody);
 
   if (isRelay) {
     // Relay station: static API key, no OAuth beta, no 1M-context stripping.

--- a/src/proxy/forwarder.js
+++ b/src/proxy/forwarder.js
@@ -2,6 +2,7 @@ import fetch from 'node-fetch';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import { createUsageTapper } from './usage-tracker.js';
 import { isOAuthRevoked } from './permission-guard.js';
+import { applyModelMap } from './model-map.js';
 
 const UPSTREAM = 'https://api.anthropic.com';
 const UPSTREAM_TIMEOUT_MS = 60_000;
@@ -60,27 +61,43 @@ const HOP_BY_HOP = new Set([
  * @param {import('./account-pool.js').AccountPool} pool
  */
 export async function forwardRequest(req, res, account, terminalId, pool, triedIds = new Set(), onFallback = null) {
+  const isRelay = account.type === 'relay';
+
   // Build upstream headers
   const upHeaders = {};
   for (const [k, v] of Object.entries(req.headers)) {
     if (!HOP_BY_HOP.has(k.toLowerCase())) upHeaders[k] = v;
   }
-  upHeaders['authorization'] = `Bearer ${account.credentials.accessToken}`;
-  upHeaders['anthropic-beta'] = addOAuthBeta(upHeaders['anthropic-beta']);
-  // Pro accounts don't support 1M context window; strip the flag so Opus works with 200K.
-  // Max accounts keep it as-is.
-  if (account.plan !== 'max') {
-    upHeaders['anthropic-beta'] = upHeaders['anthropic-beta']
-      .split(',').filter(b => b.trim() !== 'context-1m-2025-08-07').join(',');
-  }
-  if (!upHeaders['anthropic-version']) upHeaders['anthropic-version'] = '2023-06-01';
 
-  const url = UPSTREAM + req.url;
+  let outBody = req.method !== 'GET' && req.method !== 'HEAD' ? req.rawBody : undefined;
+
+  if (isRelay) {
+    // Relay station: static API key, no OAuth beta, no 1M-context stripping.
+    upHeaders['x-api-key'] = account.credentials.apiKey;
+    if (!upHeaders['anthropic-version']) upHeaders['anthropic-version'] = '2023-06-01';
+    // Apply per-relay model-name remapping (body.model rewrite) before forwarding.
+    if (outBody && account.modelMap) {
+      outBody = applyModelMap(outBody, account.modelMap);
+    }
+  } else {
+    upHeaders['authorization'] = `Bearer ${account.credentials.accessToken}`;
+    upHeaders['anthropic-beta'] = addOAuthBeta(upHeaders['anthropic-beta']);
+    // Pro accounts don't support 1M context window; strip the flag so Opus works with 200K.
+    // Max accounts keep it as-is.
+    if (account.plan !== 'max') {
+      upHeaders['anthropic-beta'] = upHeaders['anthropic-beta']
+        .split(',').filter(b => b.trim() !== 'context-1m-2025-08-07').join(',');
+    }
+    if (!upHeaders['anthropic-version']) upHeaders['anthropic-version'] = '2023-06-01';
+  }
+
+  const baseUrl = isRelay ? (account.baseUrl || UPSTREAM) : UPSTREAM;
+  const url = baseUrl.replace(/\/$/, '') + req.url;
 
   const fetchOpts = {
     method: req.method,
     headers: upHeaders,
-    body: req.method !== 'GET' && req.method !== 'HEAD' ? req.rawBody : undefined,
+    body: outBody,
     compress: false,
     ...(proxyAgent && { agent: proxyAgent }),
   };
@@ -102,7 +119,9 @@ export async function forwardRequest(req, res, account, terminalId, pool, triedI
 
   // Handle token expiry: reload from disk first (admin may have refreshed),
   // then fall back to calling the refresh endpoint. Retry once.
-  if (upRes.status === 401) {
+  // Relay accounts use a static apiKey — a 401 there means the key is bad;
+  // pass the error through so the admin can see it.
+  if (upRes.status === 401 && !isRelay) {
     console.log(`[fwd] 401 for account ${account.id}, reloading credentials from disk`);
     try {
       await pool.reloadAccount(account.id);

--- a/src/proxy/model-map.js
+++ b/src/proxy/model-map.js
@@ -1,0 +1,36 @@
+/**
+ * Apply a relay-station model mapping to an outgoing Anthropic-API request body.
+ *
+ * Third-party relays often only serve a subset of Claude model names (e.g. a
+ * station that has `claude-opus-4-5-20250929` but not `claude-opus-4-7`). The
+ * admin configures `modelMap: { opus?, sonnet?, haiku? }` per relay account;
+ * this function rewrites `body.model` based on its prefix so requests succeed.
+ *
+ * - Matching is by prefix on `claude-opus*` / `claude-sonnet*` / `claude-haiku*`
+ * - Any unset tier passes through unchanged
+ * - Non-claude models and non-JSON bodies are returned as-is
+ *
+ * @param {Buffer} bodyBuf Raw request body
+ * @param {{opus?:string, sonnet?:string, haiku?:string}|null|undefined} modelMap
+ * @returns {Buffer} New buffer (or the original if nothing to rewrite)
+ */
+export function applyModelMap(bodyBuf, modelMap) {
+  if (!modelMap || Object.keys(modelMap).length === 0) return bodyBuf;
+  let parsed;
+  try {
+    parsed = JSON.parse(bodyBuf.toString());
+  } catch {
+    return bodyBuf;
+  }
+  const model = parsed?.model;
+  if (typeof model !== 'string') return bodyBuf;
+
+  let target = null;
+  if (model.startsWith('claude-opus') && modelMap.opus) target = modelMap.opus;
+  else if (model.startsWith('claude-sonnet') && modelMap.sonnet) target = modelMap.sonnet;
+  else if (model.startsWith('claude-haiku') && modelMap.haiku) target = modelMap.haiku;
+
+  if (!target || target === model) return bodyBuf;
+  parsed.model = target;
+  return Buffer.from(JSON.stringify(parsed));
+}

--- a/src/proxy/thinking-strip.js
+++ b/src/proxy/thinking-strip.js
@@ -1,0 +1,39 @@
+/**
+ * Strip `thinking` content blocks from historical assistant messages.
+ *
+ * Anthropic's extended-thinking API returns `thinking` blocks that carry a
+ * signature (HMAC) tied to the generating account. When the client replays
+ * these blocks in a follow-up request, the upstream verifies the signature
+ * against the CURRENT account. If the pool rotated accounts between turns
+ * (OAuth → relay, relay → OAuth, or one OAuth → another), the signature
+ * check fails with:
+ *
+ *   messages.N.content.M: Invalid `signature` in `thinking` block
+ *
+ * Dropping these blocks before forwarding avoids the mismatch. The model
+ * re-derives thinking each turn anyway, so correctness is preserved —
+ * only cross-turn thinking continuity is lost.
+ *
+ * @param {Buffer} bodyBuf
+ * @returns {Buffer} original buffer (unchanged) or rewritten buffer
+ */
+export function stripThinkingBlocks(bodyBuf) {
+  if (!bodyBuf || bodyBuf.length === 0) return bodyBuf;
+  let parsed;
+  try { parsed = JSON.parse(bodyBuf.toString()); } catch { return bodyBuf; }
+  if (!Array.isArray(parsed?.messages)) return bodyBuf;
+
+  let mutated = false;
+  for (const msg of parsed.messages) {
+    if (msg.role !== 'assistant' || !Array.isArray(msg.content)) continue;
+    const filtered = msg.content.filter(
+      b => b?.type !== 'thinking' && b?.type !== 'redacted_thinking'
+    );
+    if (filtered.length !== msg.content.length) {
+      msg.content = filtered;
+      mutated = true;
+    }
+  }
+  if (!mutated) return bodyBuf;
+  return Buffer.from(JSON.stringify(parsed));
+}

--- a/tests/account-pool.test.js
+++ b/tests/account-pool.test.js
@@ -59,8 +59,8 @@ test('manual mode throws 503 if circuit breaker is open', () => {
 test('auto mode picks account with most 5h tokens remaining', () => {
   const pool = new AccountPool({
     accounts: [
-      makeAccount('acc_low', { used5h: 80000 }),
-      makeAccount('acc_high', { used5h: 20000 }),
+      makeAccount('acc_low', { utilization: 0.8 }),
+      makeAccount('acc_high', { utilization: 0.2 }),
     ],
     terminals: [],
   });
@@ -234,12 +234,14 @@ test('auto mode uses weekly utilization as tiebreaker', () => {
 
 test('updateRateLimit updates account in memory', () => {
   const acc = makeAccount('acc_1');
+  const resetEpoch = Math.floor((Date.now() + 3600000) / 1000);
   const pool = new AccountPool({ accounts: [acc], terminals: [] });
   pool.updateRateLimit('acc_1', {
-    'x-ratelimit-tokens-limit': '100000',
-    'x-ratelimit-tokens-remaining': '70000',
-    'x-ratelimit-tokens-reset': new Date(Date.now() + 3600000).toISOString(),
+    'anthropic-ratelimit-unified-5h-utilization': '0.3',
+    'anthropic-ratelimit-unified-5h-reset': String(resetEpoch),
+    'anthropic-ratelimit-unified-5h-status': 'allowed',
   });
   const updated = pool.getAccount('acc_1');
-  assert.equal(updated.rateLimit.window5h.used, 30000);
+  assert.equal(updated.rateLimit.window5h.utilization, 0.3);
+  assert.equal(updated.rateLimit.window5h.status, 'allowed');
 });

--- a/tests/relay-account.test.js
+++ b/tests/relay-account.test.js
@@ -1,0 +1,213 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AccountPool } from '../src/proxy/account-pool.js';
+import { applyModelMap } from '../src/proxy/model-map.js';
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function makeOAuth(id, opts = {}) {
+  return {
+    id,
+    type: 'oauth',
+    email: `${id}@example.com`,
+    plan: 'pro',
+    credentials: {
+      accessToken: 'tok',
+      refreshToken: 'ref',
+      expiresAt: Date.now() + 3600000,
+      scopes: ['user:inference'],
+    },
+    status: opts.status ?? 'idle',
+    cooldownUntil: null,
+    rateLimit: {
+      window5h: {
+        utilization: opts.utilization5h ?? 0,
+        resetAt: opts.w5hResetAt ?? (Date.now() + 3600000),
+        status: opts.w5hStatus ?? 'allowed',
+      },
+      weekly: {
+        utilization: opts.weeklyUtilization ?? 0,
+        resetAt: opts.weeklyResetAt ?? (Date.now() + 86400000),
+        status: opts.weeklyStatus ?? 'allowed',
+      },
+    },
+    addedAt: opts.addedAt ?? Date.now(),
+  };
+}
+
+function makeRelay(id, opts = {}) {
+  return {
+    id,
+    type: 'relay',
+    nickname: opts.nickname ?? `relay-${id}`,
+    baseUrl: opts.baseUrl ?? 'https://api.example-relay.com',
+    credentials: { apiKey: opts.apiKey ?? 'sk-relay-test' },
+    modelMap: opts.modelMap ?? {},
+    status: opts.status ?? 'idle',
+    addedAt: opts.addedAt ?? Date.now(),
+  };
+}
+
+function makeTerminal(id, mode, accountId = null) {
+  return { id, name: 'test', mode, accountId, createdAt: Date.now(), lastUsedAt: null };
+}
+
+// ── AccountPool: relay selection ──────────────────────────────────────────
+
+test('relay is NOT selected in auto mode when an OAuth account is available', () => {
+  const pool = new AccountPool({
+    accounts: [makeOAuth('acc_oauth'), makeRelay('acc_relay')],
+    terminals: [],
+  });
+  const acc = pool.selectAccount(makeTerminal('sk-1', 'auto'));
+  assert.equal(acc.id, 'acc_oauth');
+  assert.equal(acc.type, 'oauth');
+});
+
+test('relay IS selected in auto mode when all OAuth accounts are exhausted', () => {
+  const pool = new AccountPool({
+    accounts: [
+      makeOAuth('acc_oauth_a', { status: 'exhausted' }),
+      makeOAuth('acc_oauth_b', { status: 'exhausted' }),
+      makeRelay('acc_relay'),
+    ],
+    terminals: [],
+  });
+  const acc = pool.selectAccount(makeTerminal('sk-1', 'auto'));
+  assert.equal(acc.id, 'acc_relay');
+  assert.equal(acc.type, 'relay');
+});
+
+test('relay IS selected in auto mode when all OAuth accounts are cooling', () => {
+  const now = Date.now();
+  const pool = new AccountPool({
+    accounts: [
+      makeOAuth('acc_oauth', { utilization5h: 1.0, w5hResetAt: now + 60000, w5hStatus: 'blocked' }),
+      makeRelay('acc_relay'),
+    ],
+    terminals: [],
+  });
+  const acc = pool.selectAccount(makeTerminal('sk-1', 'auto'));
+  assert.equal(acc.id, 'acc_relay');
+});
+
+test('among multiple relays, oldest addedAt wins', () => {
+  const pool = new AccountPool({
+    accounts: [
+      makeOAuth('acc_oauth', { status: 'exhausted' }),
+      makeRelay('acc_relay_b', { addedAt: 2000 }),
+      makeRelay('acc_relay_a', { addedAt: 1000 }),
+    ],
+    terminals: [],
+  });
+  const acc = pool.selectAccount(makeTerminal('sk-1', 'auto'));
+  assert.equal(acc.id, 'acc_relay_a');
+});
+
+test('manual mode pins to a relay account when specified', () => {
+  const pool = new AccountPool({
+    accounts: [makeOAuth('acc_oauth'), makeRelay('acc_relay')],
+    terminals: [],
+  });
+  const acc = pool.selectAccount(makeTerminal('sk-1', 'manual', 'acc_relay'));
+  assert.equal(acc.id, 'acc_relay');
+});
+
+test('exhausted relays are not selected', () => {
+  const pool = new AccountPool({
+    accounts: [
+      makeOAuth('acc_oauth', { status: 'exhausted' }),
+      makeRelay('acc_relay', { status: 'exhausted' }),
+    ],
+    terminals: [],
+  });
+  assert.throws(
+    () => pool.selectAccount(makeTerminal('sk-1', 'auto')),
+    { message: /503/ },
+  );
+});
+
+test('selectFallback prefers OAuth, then relay', () => {
+  const now = Date.now();
+  const pool = new AccountPool({
+    accounts: [
+      makeOAuth('acc_oauth_a'),
+      makeOAuth('acc_oauth_b'),
+      makeRelay('acc_relay'),
+    ],
+    terminals: [],
+  });
+  // Exclude first oauth: fallback should be second oauth, not relay
+  let fb = pool.selectFallback(new Set(['acc_oauth_a']));
+  assert.equal(fb.id, 'acc_oauth_b');
+  // Exclude both oauth: fallback is the relay
+  fb = pool.selectFallback(new Set(['acc_oauth_a', 'acc_oauth_b']));
+  assert.equal(fb.id, 'acc_relay');
+});
+
+// ── AccountPool: ensureFreshToken ─────────────────────────────────────────
+
+test('ensureFreshToken returns relay account unchanged, without refresh', async () => {
+  const relay = makeRelay('acc_relay');
+  // Deliberately leave expiresAt undefined — would blow up if token-manager runs
+  const pool = new AccountPool({
+    accounts: [relay],
+    terminals: [],
+    configStore: { readAccounts: async () => [], writeAccounts: async () => {} },
+  });
+  const result = await pool.ensureFreshToken(relay);
+  assert.equal(result.id, 'acc_relay');
+  assert.equal(result.credentials.apiKey, 'sk-relay-test');
+});
+
+// ── applyModelMap ─────────────────────────────────────────────────────────
+
+test('applyModelMap rewrites opus when opus target set', () => {
+  const body = Buffer.from(JSON.stringify({ model: 'claude-opus-4-7', messages: [] }));
+  const out = applyModelMap(body, { opus: 'claude-opus-4-5-20250929' });
+  const parsed = JSON.parse(out.toString());
+  assert.equal(parsed.model, 'claude-opus-4-5-20250929');
+});
+
+test('applyModelMap rewrites sonnet by prefix match', () => {
+  const body = Buffer.from(JSON.stringify({ model: 'claude-sonnet-4-5-20250929', messages: [] }));
+  const out = applyModelMap(body, { sonnet: 'claude-sonnet-4-20250514' });
+  assert.equal(JSON.parse(out.toString()).model, 'claude-sonnet-4-20250514');
+});
+
+test('applyModelMap leaves haiku unchanged if haiku target not set', () => {
+  const body = Buffer.from(JSON.stringify({ model: 'claude-haiku-4-5-20251001', messages: [] }));
+  const out = applyModelMap(body, { opus: 'x' });
+  assert.equal(JSON.parse(out.toString()).model, 'claude-haiku-4-5-20251001');
+});
+
+test('applyModelMap leaves body unchanged when modelMap is empty', () => {
+  const body = Buffer.from(JSON.stringify({ model: 'claude-opus-4-7' }));
+  const out = applyModelMap(body, {});
+  assert.equal(JSON.parse(out.toString()).model, 'claude-opus-4-7');
+});
+
+test('applyModelMap leaves body unchanged when modelMap is null/undefined', () => {
+  const body = Buffer.from(JSON.stringify({ model: 'claude-opus-4-7' }));
+  assert.equal(JSON.parse(applyModelMap(body, null).toString()).model, 'claude-opus-4-7');
+  assert.equal(JSON.parse(applyModelMap(body, undefined).toString()).model, 'claude-opus-4-7');
+});
+
+test('applyModelMap ignores non-claude models', () => {
+  const body = Buffer.from(JSON.stringify({ model: 'gpt-4o-mini' }));
+  const out = applyModelMap(body, { opus: 'x', sonnet: 'y', haiku: 'z' });
+  assert.equal(JSON.parse(out.toString()).model, 'gpt-4o-mini');
+});
+
+test('applyModelMap returns original buffer if body is not valid JSON', () => {
+  const body = Buffer.from('not json');
+  const out = applyModelMap(body, { opus: 'x' });
+  assert.equal(out.toString(), 'not json');
+});
+
+test('applyModelMap handles missing model field gracefully', () => {
+  const body = Buffer.from(JSON.stringify({ messages: [] }));
+  const out = applyModelMap(body, { opus: 'x' });
+  const parsed = JSON.parse(out.toString());
+  assert.equal(parsed.model, undefined);
+});


### PR DESCRIPTION
## Summary

- 新增 `type: 'relay'` 账号类型，支持通过静态 API Key + 自定义 Base URL 添加第三方中转站
- 自动调度三级 fallback：OAuth 可用 → 中转站 → 冷却中的 OAuth
- 可选三档模型名映射（opus/sonnet/haiku），按前缀匹配改写请求 body.model
- 管理面板新增"添加中转"按钮、RelayModal 表单、中转卡片展示
- 新增 `POST /api/accounts/relay` 管理端点（仅管理员）
- 16 个新测试 + 修复 2 个已有测试，共 88/88 通过

Closes #32

## Test plan

- [x] `npm test` — 88/88 pass（含 16 个 relay 专项测试）
- [x] `npm run build` — 前端构建成功
- [ ] 手动验证：启动服务 → 添加中转站 → 确认 config/accounts.json 写入
- [ ] 手动验证：暂停所有 OAuth 账号 → 发请求 → 确认走 relay
- [ ] 手动验证：配置模型映射 → 确认 body.model 被改写
- [ ] 手动验证：恢复 OAuth 账号 → 确认调度回到 OAuth

🤖 Generated with [Claude Code](https://claude.com/claude-code)