### PR TITLE
fix(relay): 中转站账号无法被强制下线

### DIFF
--- a/src/admin/frontend/src/components/AccountsTab.jsx
+++ b/src/admin/frontend/src/components/AccountsTab.jsx
@@ -318,6 +318,7 @@ export default function AccountsTab({ accounts, terminals, onRefresh, onNewTermi
 
   function statusDot(acc) {
     if (acc.type === 'relay') {
+      if (acc.status === 'exhausted') return 'dot-red'
       if (acc.health?.status === 'offline') return 'dot-red'
       if (acc.health?.status === 'online') return 'dot-green'
       return 'dot-gray'

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -421,13 +421,16 @@ async function syncRateLimit(acc) {
     });
 
     // Detect permanent OAuth revocation — Anthropic returns 403 permission_error
+    // or 400 invalid_request_error (e.g. "This organization has been disabled.")
     // when the org's OAuth access has been revoked (plan downgraded, org banned).
     // Mark the account exhausted so UI/selection treats it as permanently offline;
     // the sync-usage endpoints notice the status transition and migrate terminals.
-    if (res.status === 403) {
+    if (res.status === 400 || res.status === 403) {
       const body = await res.text();
-      if (isOAuthRevoked(res.status, body)) {
-        console.warn(`[syncRateLimit] 403 permission_error on ${acc.email ?? acc.id}, marking exhausted`);
+      const headers = Object.fromEntries(res.headers.entries());
+      if (isOAuthRevoked(res.status, body, headers)) {
+        const via = res.status === 400 ? '400 disabled/banned' : '403 permission_error';
+        console.warn(`[syncRateLimit] ${via} on ${acc.email ?? acc.id}, marking exhausted`);
         acc.status = 'exhausted';
         acc.plan = 'free';
       }

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -389,6 +389,7 @@ async function probeAndCacheRelay(acc) {
 async function syncRateLimit(acc) {
   // Relay accounts: probe health instead of reading Anthropic rate-limit headers.
   if (acc.type === 'relay') {
+    if (acc.status === 'exhausted') return;
     await probeAndCacheRelay(acc);
     return;
   }
@@ -598,6 +599,7 @@ async function probeAllRelays() {
     const accounts = await configStore.readAccounts();
     for (const acc of accounts) {
       if (acc.type !== 'relay') continue;
+      if (acc.status === 'exhausted') continue;
       await probeAndCacheRelay(acc);
     }
   } catch (err) {

--- a/src/proxy/account-pool.js
+++ b/src/proxy/account-pool.js
@@ -143,15 +143,22 @@ export class AccountPool {
     if (!acc) return;
     acc.status = 'exhausted';
     acc.plan = 'free';   // OAuth revocation typically means the org lost its paid plan
-    try {
-      const disk = await this.#configStore.readAccounts();
-      const onDisk = disk.find(a => a.id === accountId);
-      if (onDisk && (onDisk.status !== 'exhausted' || onDisk.plan !== 'free')) {
-        onDisk.status = 'exhausted';
-        onDisk.plan = 'free';
-        await this.#configStore.writeAccounts(disk);
+    // Retry up to 3 times so _mergeFromDisk doesn't revert in-memory state
+    // when a disk write fails transiently.
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        const disk = await this.#configStore.readAccounts();
+        const onDisk = disk.find(a => a.id === accountId);
+        if (onDisk && (onDisk.status !== 'exhausted' || onDisk.plan !== 'free')) {
+          onDisk.status = 'exhausted';
+          onDisk.plan = 'free';
+          await this.#configStore.writeAccounts(disk);
+        }
+        break;
+      } catch {
+        if (attempt < 2) await new Promise(r => setTimeout(r, 100 * (attempt + 1)));
       }
-    } catch { /* non-fatal: admin will persist on next probe */ }
+    }
   }
 
   /**
@@ -164,6 +171,9 @@ export class AccountPool {
     if (!isExpired(account)) return account;
     const update = await refreshToken(account);
     Object.assign(account.credentials, update.credentials);
+    // Guard: if account was concurrently deleted (merge picked up admin deletion),
+    // don't write — it would resurrect the deleted account on disk.
+    if (!this.#accounts.some(a => a.id === account.id)) return account;
     // Read-patch-write: only persist credentials, never overwrite admin-managed
     // fields (modelMap, probeModel, nickname, etc.) with stale in-memory values.
     try {

--- a/src/proxy/account-pool.js
+++ b/src/proxy/account-pool.js
@@ -305,38 +305,38 @@ export class AccountPool {
     return this.#rateQueues.get(accountId);
   }
 
-  #startWatch() {
-    // Merge helper: sync credentials and account list from disk without overwriting
-    // in-memory rate-limit state (which is fresher from actual API response headers).
-    const mergeFromDisk = async () => {
-      try {
-        const fresh = await this.#configStore.readAccounts();
-        for (const freshAcc of fresh) {
-          const mem = this.#accounts.find(a => a.id === freshAcc.id);
-          if (mem) {
-            // Only update credentials if they changed (admin refreshed token)
-            if (freshAcc.credentials?.accessToken !== mem.credentials?.accessToken) {
-              Object.assign(mem.credentials, freshAcc.credentials);
-            }
+  // Sync credentials, status, and account list from disk without overwriting
+  // in-memory rate-limit state (which is fresher from actual API response headers).
+  // Exposed (underscore-prefixed) so tests can drive it directly.
+  async _mergeFromDisk() {
+    try {
+      const fresh = await this.#configStore.readAccounts();
+      for (const freshAcc of fresh) {
+        const mem = this.#accounts.find(a => a.id === freshAcc.id);
+        if (mem) {
+          // Sync status so admin force-online/force-offline takes effect in the proxy.
+          if (freshAcc.status !== mem.status) mem.status = freshAcc.status;
+          if (freshAcc.credentials?.accessToken !== mem.credentials?.accessToken) {
+            Object.assign(mem.credentials, freshAcc.credentials);
           }
         }
-        // Add/remove accounts that were added/deleted via admin
-        const freshIds = new Set(fresh.map(a => a.id));
-        const memIds = new Set(this.#accounts.map(a => a.id));
-        for (const a of fresh) if (!memIds.has(a.id)) this.#accounts.push(a);
-        this.#accounts = this.#accounts.filter(a => freshIds.has(a.id));
-      } catch { /* ignore */ }
-    };
+      }
+      const freshIds = new Set(fresh.map(a => a.id));
+      const memIds = new Set(this.#accounts.map(a => a.id));
+      for (const a of fresh) if (!memIds.has(a.id)) this.#accounts.push(a);
+      this.#accounts = this.#accounts.filter(a => freshIds.has(a.id));
+    } catch { /* ignore */ }
+  }
 
+  #startWatch() {
+    const merge = () => this._mergeFromDisk();
     try {
-      // fs.watch fires when admin writes accounts.json — merge credentials only,
-      // never do a full replace that would overwrite fresher in-memory rate-limit state.
-      this.#watcher = watch(this.#configStore.accountsPath, { persistent: false }, mergeFromDisk);
+      this.#watcher = watch(this.#configStore.accountsPath, { persistent: false }, merge);
     } catch {
       // fs.watch not available in test environments
     }
     // Polling fallback for WSL2 where fs.watch is unreliable (inotify limitations).
-    setInterval(mergeFromDisk, 15000).unref();
+    setInterval(merge, 15000).unref();
   }
 
   #startProactiveRefresh() {

--- a/src/proxy/account-pool.js
+++ b/src/proxy/account-pool.js
@@ -164,7 +164,16 @@ export class AccountPool {
     if (!isExpired(account)) return account;
     const update = await refreshToken(account);
     Object.assign(account.credentials, update.credentials);
-    await this.#configStore.writeAccounts(this.#accounts).catch(() => {});
+    // Read-patch-write: only persist credentials, never overwrite admin-managed
+    // fields (modelMap, probeModel, nickname, etc.) with stale in-memory values.
+    try {
+      const disk = await this.#configStore.readAccounts();
+      const onDisk = disk.find(a => a.id === account.id);
+      if (onDisk) {
+        Object.assign(onDisk.credentials, account.credentials);
+        await this.#configStore.writeAccounts(disk);
+      }
+    } catch { /* non-fatal: next merge will reconcile */ }
     return account;
   }
 
@@ -305,20 +314,26 @@ export class AccountPool {
     return this.#rateQueues.get(accountId);
   }
 
-  // Sync credentials, status, and account list from disk without overwriting
-  // in-memory rate-limit state (which is fresher from actual API response headers).
-  // Exposed (underscore-prefixed) so tests can drive it directly.
+  // Sync all fields from disk without overwriting in-memory rate-limit state
+  // (which is fresher from actual API response headers) or in-memory credentials
+  // that are fresher (higher expiresAt). This ensures admin changes (modelMap,
+  // probeModel, nickname, status, etc.) propagate to the proxy promptly.
   async _mergeFromDisk() {
     try {
       const fresh = await this.#configStore.readAccounts();
       for (const freshAcc of fresh) {
         const mem = this.#accounts.find(a => a.id === freshAcc.id);
         if (mem) {
-          // Sync status so admin force-online/force-offline takes effect in the proxy.
-          if (freshAcc.status !== mem.status) mem.status = freshAcc.status;
-          if (freshAcc.credentials?.accessToken !== mem.credentials?.accessToken) {
-            Object.assign(mem.credentials, freshAcc.credentials);
-          }
+          // Preserve in-memory rate-limit (fresher from API response headers).
+          const memRateLimit = mem.rateLimit;
+          // Keep whichever credentials have the later expiry — proxy may have just
+          // refreshed the token in memory while admin wrote an older snapshot.
+          const memExpires = mem.credentials?.expiresAt ?? 0;
+          const diskExpires = freshAcc.credentials?.expiresAt ?? 0;
+          const fresherCreds = memExpires >= diskExpires ? mem.credentials : freshAcc.credentials;
+          Object.assign(mem, freshAcc);
+          mem.rateLimit = memRateLimit;
+          mem.credentials = fresherCreds;
         }
       }
       const freshIds = new Set(fresh.map(a => a.id));

--- a/src/proxy/forwarder.js
+++ b/src/proxy/forwarder.js
@@ -151,12 +151,39 @@ export async function forwardRequest(req, res, account, terminalId, pool, triedI
     }
   }
 
+  // HTTP 400 may indicate a permanently disabled/banned account
+  // (e.g. "This organization has been disabled.").
+  // Check before generic 4xx handling so we can mark it exhausted.
+  if (upRes.status === 400) {
+    const bodyText = await upRes.text();
+    const respHeaders = Object.fromEntries(upRes.headers.entries());
+    if (isOAuthRevoked(upRes.status, bodyText, respHeaders)) {
+      console.warn(`[fwd] 400 disabled/banned on ${account.email ?? account.id}, marking exhausted and falling back`);
+      pool.markUnauthorized(account.id).catch(() => {});
+      triedIds.add(account.id);
+      const fallback = pool.selectFallback(triedIds);
+      if (fallback) {
+        onFallback?.(fallback);
+        return forwardRequest(req, res, fallback, terminalId, pool, triedIds, onFallback);
+      }
+      res.status(503).json({ error: 'no_available_accounts', message: 'account disabled and no fallback available' });
+      return;
+    }
+    // Not a ban — forward body as-is
+    for (const [k, v] of upRes.headers.entries()) {
+      if (!HOP_BY_HOP.has(k.toLowerCase())) res.setHeader(k, v);
+    }
+    res.status(400).end(bodyText);
+    return;
+  }
+
   // Permanent authorization failure: OAuth has been revoked at Anthropic (org
   // banned, plan downgraded). x-should-retry: false — don't retry this account.
   // Mark it exhausted so future selections skip it, then fall back silently.
   if (upRes.status === 403) {
     const bodyText = await upRes.text();
-    if (isOAuthRevoked(upRes.status, bodyText)) {
+    const respHeaders = Object.fromEntries(upRes.headers.entries());
+    if (isOAuthRevoked(upRes.status, bodyText, respHeaders)) {
       console.warn(`[fwd] 403 permission_error on ${account.email ?? account.id}, marking exhausted and falling back`);
       pool.markUnauthorized(account.id).catch(() => {});
       triedIds.add(account.id);

--- a/src/proxy/permission-guard.js
+++ b/src/proxy/permission-guard.js
@@ -4,25 +4,41 @@
  * plan was downgraded, the subscription was cancelled, or the org
  * was banned from OAuth-based access).
  *
- * Signal — HTTP 403 with JSON body `{error:{type:"permission_error"}}`
- * and `x-should-retry: false`. The response header is not passed here;
- * the JSON body alone is specific enough because any 403
- * permission_error we've seen on this endpoint has always been paired
- * with x-should-retry: false. Other 403s (e.g. model access denied for
- * a specific request) use `authentication_error` or similar types and
- * should NOT cause the account to be marked exhausted.
+ * Signals:
+ * - HTTP 403 with JSON body `{error:{type:"permission_error"}}`
+ * - HTTP 400 with `invalid_request_error` and permanent-ban message
+ * - `x-should-retry: false` response header (catch-all)
  *
  * @param {number} status — HTTP status code
  * @param {string | object | null | undefined} body — response body; string or pre-parsed object
+ * @param {object} [headers] — response headers (optional, for x-should-retry check)
  * @returns {boolean}
  */
-export function isOAuthRevoked(status, body) {
-  if (status !== 403) return false;
+export function isOAuthRevoked(status, body, headers) {
   if (body == null) return false;
-  try {
-    const json = typeof body === 'string' ? JSON.parse(body) : body;
-    return json?.error?.type === 'permission_error';
-  } catch {
-    return false;
+
+  // 403 + permission_error (primary signal for OAuth revocation)
+  if (status === 403) {
+    try {
+      const json = typeof body === 'string' ? JSON.parse(body) : body;
+      if (json?.error?.type === 'permission_error') return true;
+    } catch { return false; }
   }
+
+  // 400 + invalid_request_error with permanent-ban message
+  // (e.g. "This organization has been disabled.")
+  if (status === 400) {
+    try {
+      const json = typeof body === 'string' ? JSON.parse(body) : body;
+      if (json?.error?.type === 'invalid_request_error') {
+        const msg = (json.error.message ?? '').toLowerCase();
+        if (/disabled|banned|revoked|suspended/.test(msg)) return true;
+      }
+    } catch { /* not JSON */ }
+  }
+
+  // x-should-retry: false is Anthropic's generic signal for non-retriable errors
+  if (headers != null && headers['x-should-retry'] === 'false') return true;
+
+  return false;
 }

--- a/tests/account-pool.test.js
+++ b/tests/account-pool.test.js
@@ -352,3 +352,50 @@ test('updateRateLimit updates account in memory', () => {
   assert.equal(updated.rateLimit.window5h.utilization, 0.3);
   assert.equal(updated.rateLimit.window5h.status, 'allowed');
 });
+
+// ── markUnauthorized retry ────────────────────────────────────────────────
+
+test('markUnauthorized retries disk write on failure', async () => {
+  let writeAttempts = 0;
+  const mockStore = {
+    readAccounts: async () => [makeAccount('acc_1', { status: 'idle', plan: 'pro' })],
+    writeAccounts: async () => {
+      writeAttempts++;
+      if (writeAttempts < 3) throw new Error('disk write failed');
+    },
+  };
+  const pool = new AccountPool({
+    accounts: [makeAccount('acc_1', { status: 'idle', plan: 'pro' })],
+    terminals: [],
+    configStore: mockStore,
+  });
+  await pool.markUnauthorized('acc_1');
+  assert.equal(writeAttempts, 3, 'should retry until success');
+  assert.equal(pool.getAccount('acc_1').status, 'exhausted');
+  assert.equal(pool.getAccount('acc_1').plan, 'free');
+});
+
+test('markUnauthorized succeeds on first attempt', async () => {
+  let writeAttempts = 0;
+  const mockStore = {
+    readAccounts: async () => [makeAccount('acc_1', { status: 'idle', plan: 'pro' })],
+    writeAccounts: async () => { writeAttempts++; },
+  };
+  const pool = new AccountPool({
+    accounts: [makeAccount('acc_1', { status: 'idle', plan: 'pro' })],
+    terminals: [],
+    configStore: mockStore,
+  });
+  await pool.markUnauthorized('acc_1');
+  assert.equal(writeAttempts, 1);
+  assert.equal(pool.getAccount('acc_1').status, 'exhausted');
+});
+
+test('markUnauthorized handles missing account gracefully', async () => {
+  const pool = new AccountPool({
+    accounts: [],
+    terminals: [],
+  });
+  // Should not throw
+  await pool.markUnauthorized('nonexistent');
+});

--- a/tests/account-pool.test.js
+++ b/tests/account-pool.test.js
@@ -26,6 +26,8 @@ function makeAccount(id, opts = {}) {
       weeklyTokens: { used: 0, limit: 1000000, resetAt: Date.now() + 86400000 },
     },
     addedAt: opts.addedAt ?? Date.now(),
+    ...(opts.modelMap !== undefined && { modelMap: opts.modelMap }),
+    ...(opts.nickname !== undefined && { nickname: opts.nickname }),
   };
 }
 
@@ -212,6 +214,82 @@ test('_mergeFromDisk syncs status back to idle (admin force-online propagates)',
   });
   await pool._mergeFromDisk();
   assert.equal(pool.getAccount('acc_1').status, 'idle');
+});
+
+test('_mergeFromDisk syncs modelMap from disk (admin change propagates to proxy)', async () => {
+  const mockStore = {
+    readAccounts: async () => [makeAccount('acc_1', { modelMap: { opus: 'claude-opus-4-7' } })],
+    writeAccounts: async () => {},
+  };
+  const pool = new AccountPool({
+    accounts: [makeAccount('acc_1', { modelMap: {} })],
+    terminals: [],
+    configStore: mockStore,
+  });
+  await pool._mergeFromDisk();
+  assert.deepEqual(pool.getAccount('acc_1').modelMap, { opus: 'claude-opus-4-7' });
+});
+
+test('_mergeFromDisk preserves in-memory rateLimit (does not overwrite with stale disk)', async () => {
+  const memRateLimit = { window5h: { used: 500, limit: 1000 }, weekly: {} };
+  const mockStore = {
+    readAccounts: async () => [{ ...makeAccount('acc_1'), rateLimit: { window5h: { used: 0 } } }],
+    writeAccounts: async () => {},
+  };
+  const pool = new AccountPool({
+    accounts: [{ ...makeAccount('acc_1'), rateLimit: memRateLimit }],
+    terminals: [],
+    configStore: mockStore,
+  });
+  await pool._mergeFromDisk();
+  // In-memory rateLimit (used=500) must survive the disk merge
+  assert.equal(pool.getAccount('acc_1').rateLimit.window5h.used, 500);
+});
+
+test('_mergeFromDisk preserves fresher credentials (higher expiresAt wins)', async () => {
+  const now = Date.now();
+  const memExpires = now + 7200000;   // 2h from now (fresher)
+  const diskExpires = now + 3600000;  // 1h from now (staler)
+  const mockStore = {
+    readAccounts: async () => [{
+      ...makeAccount('acc_1'),
+      credentials: { accessToken: 'old-tok', refreshToken: 'old-ref', expiresAt: diskExpires },
+    }],
+    writeAccounts: async () => {},
+  };
+  const pool = new AccountPool({
+    accounts: [{
+      ...makeAccount('acc_1'),
+      credentials: { accessToken: 'new-tok', refreshToken: 'new-ref', expiresAt: memExpires },
+    }],
+    terminals: [],
+    configStore: mockStore,
+  });
+  await pool._mergeFromDisk();
+  assert.equal(pool.getAccount('acc_1').credentials.accessToken, 'new-tok');
+});
+
+test('_mergeFromDisk takes disk credentials when disk is fresher', async () => {
+  const now = Date.now();
+  const memExpires = now + 1800000;   // 30min from now (staler)
+  const diskExpires = now + 3600000;  // 1h from now (fresher — admin refreshed)
+  const mockStore = {
+    readAccounts: async () => [{
+      ...makeAccount('acc_1'),
+      credentials: { accessToken: 'admin-refreshed', refreshToken: 'ref', expiresAt: diskExpires },
+    }],
+    writeAccounts: async () => {},
+  };
+  const pool = new AccountPool({
+    accounts: [{
+      ...makeAccount('acc_1'),
+      credentials: { accessToken: 'old-tok', refreshToken: 'old-ref', expiresAt: memExpires },
+    }],
+    terminals: [],
+    configStore: mockStore,
+  });
+  await pool._mergeFromDisk();
+  assert.equal(pool.getAccount('acc_1').credentials.accessToken, 'admin-refreshed');
 });
 
 test('auto mode distributes terminals across accounts when utilization is equal', () => {

--- a/tests/account-pool.test.js
+++ b/tests/account-pool.test.js
@@ -185,6 +185,35 @@ test('markUnauthorized for unknown id is a no-op (does not throw)', async () => 
   assert.equal(pool.getAccount('acc_1').status, 'idle');
 });
 
+test('_mergeFromDisk syncs status field (admin force-offline propagates to proxy)', async () => {
+  // Disk has acc_1 marked exhausted (admin just wrote it via force-offline).
+  const mockStore = {
+    readAccounts: async () => [makeAccount('acc_1', { status: 'exhausted' })],
+    writeAccounts: async () => {},
+  };
+  const pool = new AccountPool({
+    accounts: [makeAccount('acc_1', { status: 'idle' })],
+    terminals: [],
+    configStore: mockStore,
+  });
+  await pool._mergeFromDisk();
+  assert.equal(pool.getAccount('acc_1').status, 'exhausted');
+});
+
+test('_mergeFromDisk syncs status back to idle (admin force-online propagates)', async () => {
+  const mockStore = {
+    readAccounts: async () => [makeAccount('acc_1', { status: 'idle' })],
+    writeAccounts: async () => {},
+  };
+  const pool = new AccountPool({
+    accounts: [makeAccount('acc_1', { status: 'exhausted' })],
+    terminals: [],
+    configStore: mockStore,
+  });
+  await pool._mergeFromDisk();
+  assert.equal(pool.getAccount('acc_1').status, 'idle');
+});
+
 test('auto mode distributes terminals across accounts when utilization is equal', () => {
   const pool = new AccountPool({
     accounts: [

--- a/tests/permission-guard.test.js
+++ b/tests/permission-guard.test.js
@@ -34,3 +34,47 @@ test('isOAuthRevoked: accepts pre-parsed object', () => {
   const obj = { type: 'error', error: { type: 'permission_error' } };
   assert.equal(isOAuthRevoked(403, obj), true);
 });
+
+// ── 400 + invalid_request_error ban detection ─────────────────────────────
+
+test('isOAuthRevoked: 400 with invalid_request_error "organization disabled" is true', () => {
+  const body = '{"type":"error","error":{"type":"invalid_request_error","message":"This organization has been disabled."}}';
+  assert.equal(isOAuthRevoked(400, body), true);
+});
+
+test('isOAuthRevoked: 400 with invalid_request_error "account banned" is true', () => {
+  const body = '{"type":"error","error":{"type":"invalid_request_error","message":"Account has been banned."}}';
+  assert.equal(isOAuthRevoked(400, body), true);
+});
+
+test('isOAuthRevoked: 400 with invalid_request_error "access revoked" is true', () => {
+  const body = '{"type":"error","error":{"type":"invalid_request_error","message":"Access has been revoked."}}';
+  assert.equal(isOAuthRevoked(400, body), true);
+});
+
+test('isOAuthRevoked: 400 with invalid_request_error non-ban message is false', () => {
+  const body = '{"type":"error","error":{"type":"invalid_request_error","message":"invalid model specified"}}';
+  assert.equal(isOAuthRevoked(400, body), false);
+});
+
+test('isOAuthRevoked: 400 with other error type is false', () => {
+  const body = '{"type":"error","error":{"type":"authentication_error","message":"bad request"}}';
+  assert.equal(isOAuthRevoked(400, body), false);
+});
+
+// ── x-should-retry header ─────────────────────────────────────────────────
+
+test('isOAuthRevoked: x-should-retry: false returns true regardless of status', () => {
+  const body = '{"type":"error","error":{"type":"unknown_error","message":"unknown"}}';
+  assert.equal(isOAuthRevoked(500, body, { 'x-should-retry': 'false' }), true);
+});
+
+test('isOAuthRevoked: x-should-retry: true does not trigger', () => {
+  const body = '{"type":"error","error":{"type":"invalid_request_error","message":"disabled"}}';
+  assert.equal(isOAuthRevoked(400, body, { 'x-should-retry': 'true' }), true); // message match wins
+});
+
+test('isOAuthRevoked: missing headers param works (backward compat)', () => {
+  const body = '{"type":"error","error":{"type":"permission_error","message":"revoked"}}';
+  assert.equal(isOAuthRevoked(403, body), true);
+});


### PR DESCRIPTION
## Summary
- proxy `mergeFromDisk` 同步 `status` 字段（之前只同步 credentials，force-offline 写磁盘后 proxy 内存不知道）
- 前端 `statusDot()` relay 分支：`acc.status === 'exhausted'` 优先于 health probe
- `probeAllRelays` / `syncRateLimit` 跳过 `exhausted` 的 relay 账号，防止 probe 覆盖强制下线状态

Closes #38

## Test plan
- [x] `_mergeFromDisk syncs status field` 测试通过
- [x] `_mergeFromDisk syncs status back to idle` 测试通过
- [x] 147 tests all pass
- [x] frontend build success
- [ ] 手动：对在线 relay 点强制下线，卡片变红且不恢复