### PR TITLE
feat(accounts): 聚合卡片完整实现（后端 + Proxy + 前端）

### DIFF
--- a/src/admin/frontend/src/App.jsx
+++ b/src/admin/frontend/src/App.jsx
@@ -8,6 +8,7 @@ import UsageIntensityView from './components/UsageIntensityView.jsx'
 import GuideTab from './components/GuideTab.jsx'
 import OAuthModal from './components/OAuthModal.jsx'
 import RelayModal from './components/RelayModal.jsx'
+import AggregatedModal from './components/AggregatedModal.jsx'
 import TerminalModal from './components/TerminalModal.jsx'
 import LoginPage from './components/LoginPage.jsx'
 import ConfirmEmailPage from './components/ConfirmEmailPage.jsx'
@@ -29,6 +30,7 @@ export default function App() {
   const [usageRecords, setUsageRecords] = useState([])
   const [showOAuth, setShowOAuth] = useState(false)
   const [showRelay, setShowRelay] = useState(false)
+  const [showAggregated, setShowAggregated] = useState(false)
   const [showTerminalModal, setShowTerminalModal] = useState(false)
 
   const staleRoundsRef = useRef(0)
@@ -85,6 +87,7 @@ export default function App() {
 
   function handleOAuthSuccess() { setShowOAuth(false); refresh() }
   function handleRelaySuccess() { setShowRelay(false); refresh() }
+  function handleAggregatedSuccess() { setShowAggregated(false); refresh() }
   function handleTerminalSuccess() { setShowTerminalModal(false); refresh() }
 
   async function handleSignOut() {
@@ -169,6 +172,7 @@ export default function App() {
         setTab={setTab}
         onAddAccount={() => setShowOAuth(true)}
         onAddRelay={() => setShowRelay(true)}
+        onAddAggregated={() => setShowAggregated(true)}
         onNewTerminal={() => setShowTerminalModal(true)}
         session={session}
         isAdmin={isAdmin}
@@ -208,6 +212,13 @@ export default function App() {
 
       {showRelay && (
         <RelayModal onClose={() => setShowRelay(false)} onSuccess={handleRelaySuccess} />
+      )}
+
+      {showAggregated && (
+        <AggregatedModal
+          onClose={() => setShowAggregated(false)}
+          onSuccess={handleAggregatedSuccess}
+        />
       )}
 
       {showTerminalModal && (

--- a/src/admin/frontend/src/api.js
+++ b/src/admin/frontend/src/api.js
@@ -281,9 +281,23 @@ export async function syncAccountUsage(id) {
     await delay(400)
     const acc = _accounts.find(a => a.id === id)
     if (acc) {
-      acc.rateLimit = {
-        window5h: { utilization: Math.random() * 0.6, resetAt: Date.now() + 18000000, status: 'allowed' },
-        weekly: { utilization: Math.random() * 0.4, resetAt: Date.now() + 6 * 86400000, status: 'allowed' },
+      if (acc.type === 'aggregated') {
+        // Simulate per-provider health probes in mock mode
+        acc.providers = acc.providers?.map(p => ({
+          ...p,
+          health: {
+            status: Math.random() > 0.2 ? 'online' : 'offline',
+            latencyMs: Math.floor(Math.random() * 300 + 50),
+            model: p.probeModel || 'unknown',
+            error: null,
+            ttlMs: 42000,
+          },
+        })) ?? []
+      } else {
+        acc.rateLimit = {
+          window5h: { utilization: Math.random() * 0.6, resetAt: Date.now() + 18000000, status: 'allowed' },
+          weekly: { utilization: Math.random() * 0.4, resetAt: Date.now() + 6 * 86400000, status: 'allowed' },
+        }
       }
     }
     return JSON.parse(JSON.stringify(acc))

--- a/src/admin/frontend/src/api.js
+++ b/src/admin/frontend/src/api.js
@@ -174,6 +174,36 @@ export async function updateProbeModel(id, probeModel) {
   })
 }
 
+export async function updateAggregatedRouting(id, routing) {
+  if (USE_MOCK) {
+    await delay()
+    const acc = _accounts.find(a => a.id === id)
+    if (acc) acc.routing = routing
+    return JSON.parse(JSON.stringify(acc))
+  }
+  return apiJson(`/api/accounts/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ routing }),
+  })
+}
+
+export async function updateAggregatedProbes(id, probes) {
+  if (USE_MOCK) {
+    await delay()
+    const acc = _accounts.find(a => a.id === id)
+    if (acc) {
+      acc.providers.forEach((p, i) => {
+        if (i < probes.length) p.probeModel = probes[i]
+      })
+    }
+    return JSON.parse(JSON.stringify(acc))
+  }
+  return apiJson(`/api/accounts/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ probes }),
+  })
+}
+
 export async function listRelayModels(id) {
   if (USE_MOCK) {
     await delay(300)
@@ -216,6 +246,33 @@ export async function addRelayAccount({ nickname, baseUrl, apiKey, modelMap }) {
   return apiJson('/api/accounts/relay', {
     method: 'POST',
     body: JSON.stringify({ nickname, baseUrl, apiKey, modelMap }),
+  })
+}
+
+export async function addAggregatedAccount({ nickname, providers, routing }) {
+  if (USE_MOCK) {
+    await delay(400)
+    const newAcc = {
+      id: 'acc_agg' + Date.now(),
+      type: 'aggregated',
+      nickname,
+      status: 'idle',
+      hasCredentials: true,
+      addedAt: Date.now(),
+      providers: providers.map(p => ({
+        name: p.name,
+        baseUrl: p.baseUrl,
+        hasApiKey: true,
+        probeModel: p.probeModel ?? null,
+      })),
+      routing: routing ?? {},
+    }
+    _accounts.push(newAcc)
+    return JSON.parse(JSON.stringify(newAcc))
+  }
+  return apiJson('/api/accounts/aggregated', {
+    method: 'POST',
+    body: JSON.stringify({ nickname, providers, routing }),
   })
 }
 

--- a/src/admin/frontend/src/components/AccountsTab.jsx
+++ b/src/admin/frontend/src/components/AccountsTab.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { updateTerminal, forceOnline, forceOffline, deleteAccount, renameAccount, refreshAccountToken, syncAccountUsage, updateRelayModelMap, updateProbeModel, listRelayModels } from '../api.js'
+import { updateTerminal, forceOnline, forceOffline, deleteAccount, renameAccount, refreshAccountToken, syncAccountUsage, updateRelayModelMap, updateProbeModel, listRelayModels, updateAggregatedRouting, updateAggregatedProbes } from '../api.js'
 
 function fmtExpiry(ts) {
   if (!ts) return null
@@ -151,8 +151,170 @@ function RelayCardBody({ acc, mounted, terms }) {
   )
 }
 
+// Aggregated card body — shows providers + routing summary + per-provider health
+function AggregatedCardBody({ acc, mounted, terms }) {
+  const routingEntries = []
+  for (const key of ['opus', 'sonnet', 'haiku', 'image']) {
+    const r = acc.routing?.[key]
+    if (r) {
+      const provider = acc.providers?.[r.providerIndex]
+      routingEntries.push({ key, label: key === 'image' ? '图片' : key, model: r.model, providerName: provider?.name || `#${r.providerIndex}` })
+    }
+  }
+
+  return (
+    <>
+      <div className="card-body">
+        {mounted && <div className="mounted-label">✓ 已挂载</div>}
+        <div style={{ fontSize: 12, color: '#57534e', lineHeight: 1.6, marginBottom: 8 }}>
+          {routingEntries.map(e => (
+            <div key={e.key}><span style={{ textTransform: 'capitalize', fontWeight: 600 }}>{e.label}</span> → <code>{e.model}</code> @ {e.providerName}</div>
+          ))}
+          {routingEntries.length === 0 && <span style={{ color: '#a8a29e' }}>未配置路由</span>}
+        </div>
+        {acc.providers?.map((p, i) => (
+          <div key={i} style={{ fontSize: 11, marginBottom: 2 }}>
+            <span style={{ fontWeight: 600 }}>{p.name || `供应商 ${i + 1}`}</span>
+            {' '}
+            {p.health?.status === 'online' && <span style={{ color: '#16a34a' }}>● 连通 {p.health.latencyMs}ms</span>}
+            {p.health?.status === 'offline' && <span style={{ color: '#dc2626' }}>● 中断</span>}
+            {!p.health && <span style={{ color: '#a8a29e' }}>○ 未探测</span>}
+          </div>
+        ))}
+      </div>
+      {terms.length > 0 && (
+        <div className="card-footer">
+          {terms.map(t => <span key={t.id} className="footer-chip">{t.name}</span>)}
+        </div>
+      )}
+    </>
+  )
+}
+
+// Inline editor for aggregated account routing
+function AggregatedRoutingEditor({ acc, onAction }) {
+  const [editing, setEditing] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const tiers = ['opus', 'sonnet', 'haiku', 'image']
+  const labels = { opus: 'Opus', sonnet: 'Sonnet', haiku: 'Haiku', image: '图片' }
+  const [local, setLocal] = useState(() => {
+    const init = {}
+    for (const t of tiers) {
+      init[t] = acc.routing?.[t] ? { ...acc.routing[t] } : { providerIndex: 0, model: '' }
+    }
+    return init
+  })
+
+  async function save() {
+    const out = {}
+    for (const t of tiers) {
+      if (local[t]?.model?.trim()) {
+        out[t] = { providerIndex: local[t].providerIndex, model: local[t].model.trim() }
+      }
+    }
+    setBusy(true)
+    try { await onAction('routing:' + JSON.stringify(out)) } finally { setBusy(false) }
+    setEditing(false)
+  }
+
+  if (!editing) {
+    return (
+      <button className="action-btn" onClick={() => {
+        const init = {}
+        for (const t of tiers) {
+          init[t] = acc.routing?.[t] ? { ...acc.routing[t] } : { providerIndex: 0, model: '' }
+        }
+        setLocal(init)
+        setEditing(true)
+      }}>
+        🔀 编辑路由
+      </button>
+    )
+  }
+
+  return (
+    <div style={{ fontSize: 12, padding: '4px 0' }}>
+      {tiers.map(t => (
+        <div key={t} style={{ display: 'flex', gap: 6, marginBottom: 4, alignItems: 'center' }}>
+          <span style={{ width: 44, flexShrink: 0, color: '#78716c', fontWeight: 500 }}>{labels[t]}</span>
+          <select
+            className="inline-edit"
+            style={{ width: 100, flexShrink: 0 }}
+            value={local[t].providerIndex}
+            onChange={e => setLocal({ ...local, [t]: { ...local[t], providerIndex: parseInt(e.target.value, 10) } })}
+          >
+            {acc.providers?.map((p, i) => (
+              <option key={i} value={i}>{p.name || `供应商 ${i + 1}`}</option>
+            ))}
+          </select>
+          <input
+            className="inline-edit"
+            placeholder="模型名"
+            value={local[t].model}
+            onChange={e => setLocal({ ...local, [t]: { ...local[t], model: e.target.value } })}
+            style={{ flex: 1 }}
+          />
+        </div>
+      ))}
+      <div style={{ display: 'flex', gap: 6, marginTop: 6 }}>
+        <button className="btn btn-primary btn-sm" onClick={save} disabled={busy}>{busy ? '…' : '保存'}</button>
+        <button className="btn btn-ghost btn-sm" onClick={() => setEditing(false)}>取消</button>
+      </div>
+    </div>
+  )
+}
+
+// Inline editor for aggregated account probe models
+function AggregatedProbeEditor({ acc, onAction }) {
+  const [editing, setEditing] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [local, setLocal] = useState(() =>
+    acc.providers?.map(p => p.probeModel || '') ?? []
+  )
+
+  async function save() {
+    const probes = acc.providers?.map((_, i) => local[i]?.trim() || null) ?? []
+    setBusy(true)
+    try { await onAction('probes:' + JSON.stringify(probes)) } finally { setBusy(false) }
+    setEditing(false)
+  }
+
+  if (!editing) {
+    return (
+      <button className="action-btn" onClick={() => setEditing(true)}>
+        🩺 设置探测模型
+      </button>
+    )
+  }
+
+  return (
+    <div style={{ fontSize: 12, padding: '4px 0' }}>
+      {acc.providers?.map((p, i) => (
+        <div key={i} style={{ display: 'flex', gap: 6, marginBottom: 4, alignItems: 'center' }}>
+          <span style={{ width: 80, flexShrink: 0, color: '#78716c', fontWeight: 500 }}>{p.name || `供应商 ${i + 1}`}</span>
+          <input
+            className="inline-edit"
+            placeholder="探测模型（可选）"
+            value={local[i] || ''}
+            onChange={e => {
+              const next = [...local]
+              next[i] = e.target.value
+              setLocal(next)
+            }}
+            style={{ flex: 1 }}
+          />
+        </div>
+      ))}
+      <div style={{ display: 'flex', gap: 6, marginTop: 6 }}>
+        <button className="btn btn-primary btn-sm" onClick={save} disabled={busy}>{busy ? '…' : '保存'}</button>
+        <button className="btn btn-ghost btn-sm" onClick={() => setEditing(false)}>取消</button>
+      </div>
+    </div>
+  )
+}
+
 // Per-card action panel (shown in a popover-style expanded section)
-function AccountActions({ acc, onAction, onClose }) {
+function AccountActions({ acc, onAction }) {
   const [renaming, setRenaming] = useState(false)
   const [newName, setNewName] = useState(acc.nickname || acc.email)
   const [busy, setBusy] = useState(null)
@@ -250,6 +412,12 @@ function AccountActions({ acc, onAction, onClose }) {
         </button>
       )}
 
+      {/* Aggregated routing editing */}
+      {acc.type === 'aggregated' && <AggregatedRoutingEditor acc={acc} onAction={onAction} />}
+
+      {/* Aggregated probe editing */}
+      {acc.type === 'aggregated' && <AggregatedProbeEditor acc={acc} onAction={onAction} />}
+
       {/* Online / Offline toggle */}
       {exhausted ? (
         <button className="action-btn action-btn-success" disabled={busy === 'online'} onClick={() => run('online')}>
@@ -262,7 +430,7 @@ function AccountActions({ acc, onAction, onClose }) {
       )}
 
       {/* Refresh token — OAuth only */}
-      {acc.type !== 'relay' && (
+      {acc.type !== 'relay' && acc.type !== 'aggregated' && (
         <button className="action-btn" disabled={busy === 'refresh'} onClick={() => run('refresh')}>
           {busy === 'refresh' ? '…' : '🔑 刷新 Token'}
         </button>
@@ -317,8 +485,16 @@ export default function AccountsTab({ accounts, terminals, onRefresh, onNewTermi
   }
 
   function statusDot(acc) {
-    if (acc.type === 'relay') {
+    if (acc.type === 'relay' || acc.type === 'aggregated') {
       if (acc.status === 'exhausted') return 'dot-red'
+      // aggregated: check all provider healths
+      if (acc.type === 'aggregated' && acc.providers) {
+        const allOnline = acc.providers.every(p => !p.health || p.health.status === 'online')
+        const anyOffline = acc.providers.some(p => p.health?.status === 'offline')
+        if (anyOffline) return 'dot-red'
+        if (allOnline && acc.providers.some(p => p.health)) return 'dot-green'
+        return 'dot-gray'
+      }
       if (acc.health?.status === 'offline') return 'dot-red'
       if (acc.health?.status === 'online') return 'dot-green'
       return 'dot-gray'
@@ -389,7 +565,7 @@ export default function AccountsTab({ accounts, terminals, onRefresh, onNewTermi
     } else if (action === 'refresh') {
       await refreshAccountToken(acc.id)
     } else if (action === 'delete') {
-      if (!window.confirm(`确认删除账号 ${acc.email}？`)) return
+      if (!window.confirm(`确认删除账号 ${acc.nickname || acc.email || acc.id}？`)) return
       // Delete: reassign ALL terminals (auto + manual)
       await reassignTerminals(acc.id, null)
       await deleteAccount(acc.id)
@@ -398,6 +574,10 @@ export default function AccountsTab({ accounts, terminals, onRefresh, onNewTermi
       await renameAccount(acc.id, action.slice(7))
     } else if (action.startsWith('modelmap:')) {
       await updateRelayModelMap(acc.id, JSON.parse(action.slice(9)))
+    } else if (action.startsWith('routing:')) {
+      await updateAggregatedRouting(acc.id, JSON.parse(action.slice(8)))
+    } else if (action.startsWith('probes:')) {
+      await updateAggregatedProbes(acc.id, JSON.parse(action.slice(7)))
     } else if (action === 'probe-modal') {
       setProbeModalAcc(acc)
       return
@@ -506,7 +686,8 @@ export default function AccountsTab({ accounts, terminals, onRefresh, onNewTermi
           const actionsOpen = expandedCard === acc.id
           const displayName = acc.nickname || acc.email
           const isRelay = acc.type === 'relay'
-          const expiry = !isRelay && fmtExpiry(acc.tokenExpiresAt)
+          const isAggregated = acc.type === 'aggregated'
+          const expiry = !isRelay && !isAggregated && fmtExpiry(acc.tokenExpiresAt)
           const reset5h = fmtReset(acc.rateLimit?.window5h?.resetAt)
           const resetWeek = fmtReset(acc.rateLimit?.weekly?.resetAt)
 
@@ -517,9 +698,11 @@ export default function AccountsTab({ accounts, terminals, onRefresh, onNewTermi
               onClick={() => !actionsOpen && mountAccount(acc)}
             >
               <div className={`card-header ${exhausted ? 'exhausted' : ''}`}>
-                <span className="card-email" title={acc.email || acc.baseUrl}>{displayName}</span>
+                <span className="card-email" title={acc.email || acc.baseUrl || displayName}>{displayName}</span>
                 {isRelay ? (
                   <span className="plan-badge badge-relay">中转</span>
+                ) : isAggregated ? (
+                  <span className="plan-badge badge-relay">聚合</span>
                 ) : (
                   <span className={`plan-badge ${acc.plan === 'max' ? 'badge-max' : acc.plan === 'free' ? 'badge-free' : 'badge-pro'}`}>
                     {acc.plan?.toUpperCase() ?? 'PRO'}
@@ -531,7 +714,7 @@ export default function AccountsTab({ accounts, terminals, onRefresh, onNewTermi
                     {/* Sync usage / health check button */}
                     <button
                       className={`card-refresh-btn${syncingId === acc.id ? ' spinning' : ''}`}
-                      title={isRelay ? '检测连通性' : '同步用量'}
+                      title={isRelay || isAggregated ? '检测连通性' : '同步用量'}
                       onClick={async e => {
                         e.stopPropagation()
                         setSyncingId(acc.id)
@@ -560,10 +743,11 @@ export default function AccountsTab({ accounts, terminals, onRefresh, onNewTermi
                 <AccountActions
                   acc={acc}
                   onAction={action => handleCardAction(acc, action)}
-                  onClose={() => setExpandedCard(null)}
                 />
               ) : isRelay ? (
                 <RelayCardBody acc={acc} mounted={mounted} terms={terms} />
+              ) : isAggregated ? (
+                <AggregatedCardBody acc={acc} mounted={mounted} terms={terms} />
               ) : (
                 <>
                   <div className="card-body">

--- a/src/admin/frontend/src/components/AggregatedModal.jsx
+++ b/src/admin/frontend/src/components/AggregatedModal.jsx
@@ -1,0 +1,181 @@
+import { useState } from 'react'
+import { addAggregatedAccount } from '../api.js'
+
+export default function AggregatedModal({ onClose, onSuccess }) {
+  const [step, setStep] = useState(1)
+  const [nickname, setNickname] = useState('')
+  const [providers, setProviders] = useState([{ name: '', baseUrl: '', apiKey: '', probeModel: '' }])
+  const [routing, setRouting] = useState({
+    opus: { providerIndex: 0, model: '' },
+    sonnet: { providerIndex: 0, model: '' },
+    haiku: { providerIndex: 0, model: '' },
+    image: { providerIndex: 0, model: '' },
+  })
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState(null)
+
+  function addProvider() {
+    setProviders([...providers, { name: '', baseUrl: '', apiKey: '', probeModel: '' }])
+  }
+
+  function removeProvider(idx) {
+    setProviders(providers.filter((_, i) => i !== idx))
+    const next = {}
+    for (const key of ['opus', 'sonnet', 'haiku', 'image']) {
+      const r = routing[key]
+      if (!r) { next[key] = { providerIndex: 0, model: '' }; continue }
+      if (r.providerIndex === idx) { next[key] = { providerIndex: 0, model: '' }; continue }
+      if (r.providerIndex > idx) { next[key] = { ...r, providerIndex: r.providerIndex - 1 }; continue }
+      next[key] = r
+    }
+    setRouting(next)
+  }
+
+  function updateProvider(idx, field, value) {
+    setProviders(providers.map((p, i) => i === idx ? { ...p, [field]: value } : p))
+  }
+
+  function updateRouting(key, field, value) {
+    setRouting({ ...routing, [key]: { ...routing[key], [field]: value } })
+  }
+
+  function validate() {
+    if (!nickname.trim()) return '请输入聚合卡片名称'
+    if (providers.length === 0) return '至少添加一个供应商'
+    for (let i = 0; i < providers.length; i++) {
+      const p = providers[i]
+      if (!p.name.trim()) return `供应商 ${i + 1} 名称不能为空`
+      if (!p.baseUrl.trim()) return `供应商 ${i + 1} Base URL 不能为空`
+      if (!p.apiKey.trim()) return `供应商 ${i + 1} API Key 不能为空`
+    }
+    if (!routing.opus?.model?.trim() && !routing.sonnet?.model?.trim() && !routing.haiku?.model?.trim()) {
+      return '至少配置 Opus、Sonnet 或 Haiku 中的一项路由'
+    }
+    return null
+  }
+
+  async function submit() {
+    const err = validate()
+    if (err) { setError(err); return }
+    setBusy(true)
+    setError(null)
+    try {
+      const cleanProviders = providers.map(p => ({
+        name: p.name.trim(),
+        baseUrl: p.baseUrl.trim(),
+        apiKey: p.apiKey.trim(),
+        probeModel: p.probeModel.trim() || undefined,
+      }))
+      const cleanRouting = {}
+      for (const key of ['opus', 'sonnet', 'haiku', 'image']) {
+        const r = routing[key]
+        if (r?.model?.trim()) {
+          cleanRouting[key] = { providerIndex: r.providerIndex, model: r.model.trim() }
+        }
+      }
+      await addAggregatedAccount({ nickname: nickname.trim(), providers: cleanProviders, routing: cleanRouting })
+      onSuccess()
+    } catch (e) {
+      setError(e.message || '创建失败')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal-box" style={{ width: 520, maxHeight: '90vh', overflowY: 'auto' }} onClick={e => e.stopPropagation()}>
+        <h3 className="modal-title">添加聚合卡片</h3>
+
+        {step === 1 && (
+          <>
+            <div className="form-row">
+              <label className="form-label">卡片名称</label>
+              <input
+                className="form-input"
+                placeholder="例如：DeepSeek + GLM"
+                value={nickname}
+                onChange={e => setNickname(e.target.value)}
+              />
+            </div>
+            <div className="modal-actions">
+              <button className="btn btn-ghost" onClick={onClose}>取消</button>
+              <button className="btn btn-primary" onClick={() => setStep(2)}>下一步</button>
+            </div>
+          </>
+        )}
+
+        {step === 2 && (
+          <>
+            <p style={{ fontSize: 12, color: '#78716c', marginBottom: 12 }}>配置上游供应商（Base URL + API Key）</p>
+            {providers.map((p, i) => (
+              <div key={i} style={{ border: '1px solid #e7e5e4', borderRadius: 8, padding: 12, marginBottom: 10 }}>
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
+                  <span style={{ fontSize: 13, fontWeight: 600 }}>供应商 {i + 1}</span>
+                  {providers.length > 1 && (
+                    <button className="btn btn-ghost btn-sm" onClick={() => removeProvider(i)}>删除</button>
+                  )}
+                </div>
+                <div className="form-row" style={{ marginBottom: 8 }}>
+                  <input className="form-input" placeholder="名称，如 DeepSeek" value={p.name} onChange={e => updateProvider(i, 'name', e.target.value)} />
+                </div>
+                <div className="form-row" style={{ marginBottom: 8 }}>
+                  <input className="form-input" placeholder="Base URL，如 https://api.deepseek.com" value={p.baseUrl} onChange={e => updateProvider(i, 'baseUrl', e.target.value)} />
+                </div>
+                <div className="form-row" style={{ marginBottom: 8 }}>
+                  <input className="form-input" placeholder="API Key" value={p.apiKey} onChange={e => updateProvider(i, 'apiKey', e.target.value)} />
+                </div>
+                <div className="form-row" style={{ marginBottom: 0 }}>
+                  <input className="form-input" placeholder="探测模型（可选）" value={p.probeModel} onChange={e => updateProvider(i, 'probeModel', e.target.value)} />
+                </div>
+              </div>
+            ))}
+            <button className="btn btn-ghost" style={{ width: '100%', marginBottom: 12 }} onClick={addProvider}>+ 添加供应商</button>
+            <div className="modal-actions">
+              <button className="btn btn-ghost" onClick={() => setStep(1)}>上一步</button>
+              <button className="btn btn-primary" onClick={() => setStep(3)}>下一步</button>
+            </div>
+          </>
+        )}
+
+        {step === 3 && (
+          <>
+            <p style={{ fontSize: 12, color: '#78716c', marginBottom: 12 }}>根据请求的模型自动路由到对应供应商</p>
+            {['opus', 'sonnet', 'haiku', 'image'].map(key => (
+              <div key={key} style={{ marginBottom: 10 }}>
+                <label className="form-label" style={{ textTransform: 'capitalize', marginBottom: 4 }}>
+                  {key === 'image' ? '图片路由（可选）' : key}
+                </label>
+                <div style={{ display: 'flex', gap: 8 }}>
+                  <select
+                    className="form-input"
+                    style={{ width: 140, flexShrink: 0 }}
+                    value={routing[key]?.providerIndex ?? 0}
+                    onChange={e => updateRouting(key, 'providerIndex', parseInt(e.target.value, 10))}
+                  >
+                    {providers.map((p, i) => (
+                      <option key={i} value={i}>{p.name || `供应商 ${i + 1}`}</option>
+                    ))}
+                  </select>
+                  <input
+                    className="form-input"
+                    placeholder="目标模型名，如 deepseek-v4-pro"
+                    value={routing[key]?.model ?? ''}
+                    onChange={e => updateRouting(key, 'model', e.target.value)}
+                  />
+                </div>
+              </div>
+            ))}
+            {error && <div className="modal-error">{error}</div>}
+            <div className="modal-actions">
+              <button className="btn btn-ghost" onClick={() => setStep(2)}>上一步</button>
+              <button className="btn btn-primary" onClick={submit} disabled={busy}>
+                {busy ? '创建中…' : '创建'}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/admin/frontend/src/components/Nav.jsx
+++ b/src/admin/frontend/src/components/Nav.jsx
@@ -1,6 +1,6 @@
 import LogoMark from './LogoMark.jsx'
 
-export default function Nav({ tab, setTab, onAddAccount, onAddRelay, onNewTerminal, session, isAdmin, onSignOut }) {
+export default function Nav({ tab, setTab, onAddAccount, onAddRelay, onAddAggregated, onNewTerminal, session, isAdmin, onSignOut }) {
   return (
     <nav className="nav">
       <div className="nav-logo"><LogoMark size={20} />claudecode-hub</div>
@@ -15,6 +15,7 @@ export default function Nav({ tab, setTab, onAddAccount, onAddRelay, onNewTermin
         {tab === 'accounts' && isAdmin && (
           <>
             <button className="btn btn-ghost" onClick={onAddRelay}>+ 添加中转</button>
+            <button className="btn btn-ghost" onClick={onAddAggregated}>+ 添加聚合</button>
             <button className="btn btn-primary" onClick={onAddAccount}>+ 添加账号</button>
           </>
         )}

--- a/src/admin/frontend/src/mock/data.js
+++ b/src/admin/frontend/src/mock/data.js
@@ -91,6 +91,48 @@ export const mockAccounts = [
     modelMap: {},
     probeModel: null,
   },
+  {
+    id: 'acc_agg01',
+    type: 'aggregated',
+    nickname: 'DeepSeek + GLM',
+    status: 'idle',
+    hasCredentials: true,
+    addedAt: now - DAY,
+    providers: [
+      {
+        name: 'DeepSeek',
+        baseUrl: 'https://api.deepseek.com',
+        hasApiKey: true,
+        probeModel: 'deepseek-v4-pro',
+        health: {
+          status: 'online',
+          latencyMs: 145,
+          model: 'deepseek-v4-pro',
+          error: null,
+          ttlMs: 38000,
+        },
+      },
+      {
+        name: 'GLM',
+        baseUrl: 'https://open.bigmodel.cn/api/paas',
+        hasApiKey: true,
+        probeModel: 'glm-5v-turbo',
+        health: {
+          status: 'online',
+          latencyMs: 210,
+          model: 'glm-5v-turbo',
+          error: null,
+          ttlMs: 38000,
+        },
+      },
+    ],
+    routing: {
+      opus: { providerIndex: 0, model: 'deepseek-v4-pro' },
+      sonnet: { providerIndex: 0, model: 'deepseek-v4-pro' },
+      haiku: { providerIndex: 0, model: 'deepseek-chat' },
+      image: { providerIndex: 1, model: 'glm-5v-turbo' },
+    },
+  },
 ]
 
 export const mockTerminals = [

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -110,6 +110,26 @@ app.patch('/api/accounts/:id', requireAdmin, async (req, res) => {
     }
     acc.modelMap = normalisedMap;
   }
+  if (req.body.routing !== undefined && acc.type === 'aggregated') {
+    const normalisedRouting = {};
+    if (req.body.routing && typeof req.body.routing === 'object') {
+      for (const tier of ['opus', 'sonnet', 'haiku', 'image']) {
+        const r = req.body.routing[tier];
+        if (r && typeof r === 'object' && typeof r.providerIndex === 'number' && typeof r.model === 'string' && r.model.trim().length > 0) {
+          normalisedRouting[tier] = { providerIndex: r.providerIndex, model: r.model.trim() };
+        }
+      }
+    }
+    acc.routing = normalisedRouting;
+  }
+  if (req.body.probes !== undefined && acc.type === 'aggregated' && Array.isArray(req.body.probes)) {
+    for (let i = 0; i < (acc.providers ?? []).length; i++) {
+      if (i < req.body.probes.length) {
+        const v = req.body.probes[i];
+        acc.providers[i].probeModel = (typeof v === 'string' && v.trim().length > 0) ? v.trim() : null;
+      }
+    }
+  }
   await configStore.writeAccounts(accounts);
   res.json(sanitiseAccount(acc));
 });
@@ -188,6 +208,58 @@ app.post('/api/accounts/relay', requireAdmin, async (req, res) => {
     baseUrl: baseUrl.replace(/\/$/, ''),
     credentials: { apiKey: apiKey.trim() },
     modelMap: normalisedMap,
+    status: 'idle',
+    addedAt: Date.now(),
+  };
+  accounts.push(acc);
+  await configStore.writeAccounts(accounts);
+  res.status(201).json(sanitiseAccount(acc));
+});
+
+// Add an aggregated routing card — multiple upstream providers behind a single
+// token, with per-tier routing (Opus/Sonnet/Haiku/Image → provider + model).
+app.post('/api/accounts/aggregated', requireAdmin, async (req, res) => {
+  const { nickname, providers, routing } = req.body ?? {};
+  if (typeof nickname !== 'string' || nickname.trim().length === 0) {
+    return res.status(400).json({ error: 'nickname_required' });
+  }
+  if (!Array.isArray(providers) || providers.length === 0) {
+    return res.status(400).json({ error: 'providers_required', message: 'At least one provider is required' });
+  }
+  const normalisedProviders = [];
+  for (const p of providers) {
+    if (typeof p.name !== 'string' || p.name.trim().length === 0) {
+      return res.status(400).json({ error: 'provider_name_required' });
+    }
+    if (typeof p.baseUrl !== 'string' || !/^https:\/\//i.test(p.baseUrl)) {
+      return res.status(400).json({ error: 'invalid_base_url', message: `Provider "${p.name}" baseUrl must start with https://` });
+    }
+    if (typeof p.apiKey !== 'string' || p.apiKey.trim().length === 0) {
+      return res.status(400).json({ error: 'api_key_required', message: `Provider "${p.name}" apiKey is required` });
+    }
+    normalisedProviders.push({
+      name: p.name.trim(),
+      baseUrl: p.baseUrl.replace(/\/$/, ''),
+      credentials: { apiKey: p.apiKey.trim() },
+      probeModel: (typeof p.probeModel === 'string' && p.probeModel.trim().length > 0) ? p.probeModel.trim() : null,
+    });
+  }
+  const normalisedRouting = {};
+  if (routing && typeof routing === 'object') {
+    for (const tier of ['opus', 'sonnet', 'haiku', 'image']) {
+      const r = routing[tier];
+      if (r && typeof r === 'object' && typeof r.providerIndex === 'number' && typeof r.model === 'string' && r.model.trim().length > 0) {
+        normalisedRouting[tier] = { providerIndex: r.providerIndex, model: r.model.trim() };
+      }
+    }
+  }
+  const accounts = await configStore.readAccounts();
+  const acc = {
+    id: `acc_${randomBytes(6).toString('hex')}`,
+    type: 'aggregated',
+    nickname: nickname.trim(),
+    providers: normalisedProviders,
+    routing: normalisedRouting,
     status: 'idle',
     addedAt: Date.now(),
   };
@@ -388,8 +460,8 @@ async function probeAndCacheRelay(acc) {
 }
 
 async function syncRateLimit(acc) {
-  // Relay accounts: probe health instead of reading Anthropic rate-limit headers.
-  if (acc.type === 'relay') {
+  // Relay / Aggregated accounts: probe health instead of reading Anthropic rate-limit headers.
+  if (acc.type === 'relay' || acc.type === 'aggregated') {
     await probeAndCacheRelay(acc);
     return;
   }
@@ -484,6 +556,22 @@ function sanitiseAccount(acc) {
             ttlMs,
           }
         : null,
+    };
+  }
+  if (acc.type === 'aggregated') {
+    // Strip apiKey from providers, replace with hasApiKey boolean
+    const providers = (acc.providers ?? []).map(p => ({
+      name: p.name,
+      baseUrl: p.baseUrl,
+      hasApiKey: !!p.credentials?.apiKey,
+      probeModel: p.probeModel ?? null,
+      health: acc.status === 'exhausted' ? null : (p.health ?? null),
+    }));
+    const hasCredentials = providers.some(p => p.hasApiKey);
+    return {
+      ...rest,
+      providers,
+      hasCredentials,
     };
   }
   return {
@@ -675,7 +763,7 @@ async function probeAllRelays() {
   try {
     const accounts = await configStore.readAccounts();
     for (const acc of accounts) {
-      if (acc.type !== 'relay') continue;
+      if (acc.type !== 'relay' && acc.type !== 'aggregated') continue;
       if (acc.status === 'exhausted') continue;
       await probeAndCacheRelay(acc);
     }

--- a/src/admin/relay-health.js
+++ b/src/admin/relay-health.js
@@ -65,8 +65,14 @@ export async function listRelayModels(acc, fetchFn) {
  * If no probe model is configured, the function returns without setting acc.health.
  */
 export async function syncRelayHealth(acc, fetchFn) {
-  if (acc.type !== 'relay') return;
+  if (acc.type === 'relay') {
+    await probeRelay(acc, fetchFn);
+  } else if (acc.type === 'aggregated') {
+    await probeAggregated(acc, fetchFn);
+  }
+}
 
+async function probeRelay(acc, fetchFn) {
   const model = pickProbeModel(acc);
   if (!model) return;
 
@@ -111,5 +117,71 @@ export async function syncRelayHealth(acc, fetchFn) {
       model,
       error: err.name === 'AbortError' ? 'timeout' : err.message,
     };
+  }
+}
+
+function pickAggregatedProbeModel(provider, routing) {
+  if (provider.probeModel && typeof provider.probeModel === 'string' && provider.probeModel.trim()) {
+    return provider.probeModel.trim();
+  }
+  if (routing) {
+    for (const tier of ['opus', 'sonnet', 'haiku', 'image']) {
+      const route = routing[tier];
+      if (route && route.providerIndex != null && route.model) {
+        return route.model;
+      }
+    }
+  }
+  return null;
+}
+
+async function probeAggregated(acc, fetchFn) {
+  const fetch = fetchFn ?? (await import('node-fetch')).default;
+
+  for (const provider of acc.providers ?? []) {
+    const model = pickAggregatedProbeModel(provider, acc.routing);
+    if (!model) continue;
+
+    const url = provider.baseUrl.replace(/\/$/, '') + '/v1/messages';
+    const start = Date.now();
+
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'x-api-key': provider.credentials.apiKey,
+          'anthropic-version': '2023-06-01',
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          model,
+          max_tokens: 5,
+          messages: [{ role: 'user', content: 'hi' }],
+        }),
+        signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+      });
+
+      const latencyMs = Date.now() - start;
+
+      if (res.ok) {
+        provider.health = { status: 'online', latencyMs, model, error: null };
+      } else {
+        const body = await res.text().catch(() => '');
+        provider.health = {
+          status: 'offline',
+          latencyMs,
+          model,
+          error: `HTTP ${res.status}: ${body.slice(0, 200)}`,
+        };
+      }
+    } catch (err) {
+      const latencyMs = Date.now() - start;
+      provider.health = {
+        status: 'offline',
+        latencyMs,
+        model,
+        error: err.name === 'AbortError' ? 'timeout' : err.message,
+      };
+    }
   }
 }

--- a/src/proxy/account-pool.js
+++ b/src/proxy/account-pool.js
@@ -86,16 +86,16 @@ export class AccountPool {
    * @param {Set<string>} excludeIds
    */
   selectFallback(excludeIds) {
-    const isRelay = (a) => a.type === 'relay';
+    const isRelay = (a) => a.type === 'relay' || a.type === 'aggregated';
     const eligible = this.#accounts
       .filter(a => !excludeIds.has(a.id) && a.status !== 'exhausted' && this.#ensureCB(a.id).canRequest());
     const oauth = eligible.filter(a => !isRelay(a));
     const warm = oauth.filter(a => !this.#isCooling(a));
     if (warm.length) return this.#leastUtilized(warm);
-    const cooling = oauth.filter(a => this.#isCooling(a));
-    if (cooling.length) return this.#soonestReset(cooling);
     const relays = eligible.filter(isRelay);
     if (relays.length) return this.#oldestRelay(relays);
+    const cooling = oauth.filter(a => this.#isCooling(a));
+    if (cooling.length) return this.#soonestReset(cooling);
     return null;
   }
 
@@ -163,7 +163,7 @@ export class AccountPool {
    * Relay accounts use a static apiKey and skip refresh entirely.
    */
   async ensureFreshToken(account) {
-    if (account.type === 'relay') return account;
+    if (account.type === 'relay' || account.type === 'aggregated') return account;
     if (!isExpired(account)) return account;
     const update = await this.#refreshToken(account);
     Object.assign(account.credentials, update.credentials);
@@ -199,7 +199,7 @@ export class AccountPool {
   }
 
   #pickAuto(preferredId = null) {
-    const isRelay = (a) => a.type === 'relay';
+    const isRelay = (a) => a.type === 'relay' || a.type === 'aggregated';
     const eligible = this.#accounts
       .filter(a => a.status !== 'exhausted' && this.#ensureCB(a.id).canRequest());
     if (eligible.length === 0) throw new Error('503: no available accounts');

--- a/src/proxy/account-pool.js
+++ b/src/proxy/account-pool.js
@@ -320,9 +320,25 @@ export class AccountPool {
         for (const freshAcc of fresh) {
           const mem = this.#accounts.find(a => a.id === freshAcc.id);
           if (mem) {
-            // Only update credentials if they changed (admin refreshed token)
-            if (freshAcc.credentials?.accessToken !== mem.credentials?.accessToken) {
-              Object.assign(mem.credentials, freshAcc.credentials);
+            // Preserve in-memory runtime state (fresher than disk)
+            const preservedRateLimit = mem.rateLimit;
+            const preservedCooldown = mem.cooldownUntil;
+            const preservedHealth = mem.health;
+            const preservedProviderHealths = mem.type === 'aggregated' && Array.isArray(mem.providers)
+              ? mem.providers.map(p => p.health)
+              : [];
+
+            // Full replace from disk
+            Object.assign(mem, freshAcc);
+
+            // Restore preserved state
+            mem.rateLimit = preservedRateLimit;
+            mem.cooldownUntil = preservedCooldown;
+            mem.health = preservedHealth;
+            if (Array.isArray(mem.providers) && preservedProviderHealths.length) {
+              for (let i = 0; i < Math.min(mem.providers.length, preservedProviderHealths.length); i++) {
+                mem.providers[i].health = preservedProviderHealths[i];
+              }
             }
           }
         }

--- a/src/proxy/aggregated-router.js
+++ b/src/proxy/aggregated-router.js
@@ -1,0 +1,49 @@
+export function hasImageContent(body) {
+  if (!body?.messages) return false;
+  for (const msg of body.messages) {
+    if (Array.isArray(msg.content)) {
+      for (const item of msg.content) {
+        if (item?.type === 'image') return true;
+      }
+    }
+  }
+  return false;
+}
+
+export function resolveAggregatedProvider(body, account) {
+  const hasImage = hasImageContent(body);
+  let route;
+
+  if (hasImage) {
+    route = account.routing?.image ?? account.routing?.opus;
+  } else {
+    const model = body.model ?? '';
+    if (model.startsWith('claude-opus')) route = account.routing?.opus;
+    else if (model.startsWith('claude-sonnet')) route = account.routing?.sonnet;
+    else if (model.startsWith('claude-haiku')) route = account.routing?.haiku;
+  }
+
+  if (!route) return null;
+
+  const provider = account.providers?.[route.providerIndex];
+  if (!provider) return null;
+
+  return {
+    baseUrl: provider.baseUrl,
+    apiKey: provider.credentials?.apiKey,
+    targetModel: route.model,
+  };
+}
+
+export function rewriteModel(bodyBuf, targetModel) {
+  try {
+    const parsed = JSON.parse(bodyBuf.toString());
+    if (typeof parsed.model === 'string' && parsed.model !== targetModel) {
+      parsed.model = targetModel;
+      return Buffer.from(JSON.stringify(parsed));
+    }
+  } catch {
+    /* ignore invalid JSON */
+  }
+  return bodyBuf;
+}

--- a/src/proxy/aggregated-router.js
+++ b/src/proxy/aggregated-router.js
@@ -1,11 +1,19 @@
+function containsImageInContentArray(content) {
+  if (!Array.isArray(content)) return false;
+  for (const item of content) {
+    if (item?.type === 'image') return true;
+    // Images can be nested inside tool_result.content
+    if (item?.type === 'tool_result' && Array.isArray(item.content)) {
+      if (containsImageInContentArray(item.content)) return true;
+    }
+  }
+  return false;
+}
+
 export function hasImageContent(body) {
   if (!body?.messages) return false;
   for (const msg of body.messages) {
-    if (Array.isArray(msg.content)) {
-      for (const item of msg.content) {
-        if (item?.type === 'image') return true;
-      }
-    }
+    if (containsImageInContentArray(msg.content)) return true;
   }
   return false;
 }

--- a/src/proxy/forwarder.js
+++ b/src/proxy/forwarder.js
@@ -4,6 +4,7 @@ import { createUsageTapper } from './usage-tracker.js';
 import { isOAuthRevoked } from './permission-guard.js';
 import { applyModelMap } from './model-map.js';
 import { stripThinkingBlocks } from './thinking-strip.js';
+import { resolveAggregatedProvider, rewriteModel } from './aggregated-router.js';
 
 const UPSTREAM = 'https://api.anthropic.com';
 const UPSTREAM_TIMEOUT_MS = 60_000;
@@ -63,6 +64,18 @@ const HOP_BY_HOP = new Set([
  */
 export async function forwardRequest(req, res, account, terminalId, pool, triedIds = new Set(), onFallback = null) {
   const isRelay = account.type === 'relay';
+  const isAggregated = account.type === 'aggregated';
+  let aggregatedProvider = null;
+
+  if (isAggregated) {
+    try {
+      const body = JSON.parse(req.rawBody?.toString() ?? '{}');
+      aggregatedProvider = resolveAggregatedProvider(body, account);
+    } catch { /* invalid JSON handled below */ }
+    if (!aggregatedProvider) {
+      return res.status(502).json({ error: 'aggregated_routing_unresolved', message: 'No provider matched for this request' });
+    }
+  }
 
   // Build upstream headers
   const upHeaders = {};
@@ -78,13 +91,16 @@ export async function forwardRequest(req, res, account, terminalId, pool, triedI
   // different upstream. See @/src/proxy/thinking-strip.js for detail.
   if (outBody) outBody = stripThinkingBlocks(outBody);
 
-  if (isRelay) {
-    // Relay station: static API key, no OAuth beta, no 1M-context stripping.
-    upHeaders['x-api-key'] = account.credentials.apiKey;
+  if (isRelay || isAggregated) {
+    // Relay / Aggregated station: static API key, no OAuth beta, no 1M-context stripping.
+    upHeaders['x-api-key'] = isAggregated ? aggregatedProvider.apiKey : account.credentials.apiKey;
     if (!upHeaders['anthropic-version']) upHeaders['anthropic-version'] = '2023-06-01';
     // Apply per-relay model-name remapping (body.model rewrite) before forwarding.
     if (outBody && account.modelMap) {
       outBody = applyModelMap(outBody, account.modelMap);
+    }
+    if (isAggregated && aggregatedProvider.targetModel) {
+      outBody = rewriteModel(outBody, aggregatedProvider.targetModel);
     }
   } else {
     upHeaders['authorization'] = `Bearer ${account.credentials.accessToken}`;
@@ -98,7 +114,9 @@ export async function forwardRequest(req, res, account, terminalId, pool, triedI
     if (!upHeaders['anthropic-version']) upHeaders['anthropic-version'] = '2023-06-01';
   }
 
-  const baseUrl = isRelay ? (account.baseUrl || UPSTREAM) : UPSTREAM;
+  const baseUrl = isRelay ? (account.baseUrl || UPSTREAM)
+    : isAggregated ? aggregatedProvider.baseUrl
+    : UPSTREAM;
   const url = baseUrl.replace(/\/$/, '') + req.url;
 
   const fetchOpts = {
@@ -126,9 +144,9 @@ export async function forwardRequest(req, res, account, terminalId, pool, triedI
 
   // Handle token expiry: reload from disk first (admin may have refreshed),
   // then fall back to calling the refresh endpoint. Retry once.
-  // Relay accounts use a static apiKey — a 401 there means the key is bad;
+  // Relay / Aggregated accounts use a static apiKey — a 401 there means the key is bad;
   // pass the error through so the admin can see it.
-  if (upRes.status === 401 && !isRelay) {
+  if (upRes.status === 401 && !isRelay && !isAggregated) {
     console.log(`[fwd] 401 for account ${account.id}, reloading credentials from disk`);
     try {
       await pool.reloadAccount(account.id);
@@ -221,8 +239,8 @@ export async function forwardRequest(req, res, account, terminalId, pool, triedI
 
   // Detect SSE
   const ct = upRes.headers.get('content-type') ?? '';
+  const model = isAggregated ? aggregatedProvider.targetModel : detectModel(req);
   if (ct.includes('text/event-stream')) {
-    const model = detectModel(req);
     const tapper = createUsageTapper({ accountId: account.id, terminalId, model });
     upRes.body.pipe(tapper).pipe(res);
     res.on('close', () => { if (!tapper.destroyed) tapper.destroy(); });
@@ -233,7 +251,6 @@ export async function forwardRequest(req, res, account, terminalId, pool, triedI
     try {
       const json = JSON.parse(body.toString());
       if (json.usage) {
-        const model = detectModel(req);
         const { input_tokens: inTok = 0, output_tokens: outTok = 0 } = json.usage;
         // Write via tapper helper directly
         const tapper = createUsageTapper({ accountId: account.id, terminalId, model });

--- a/src/proxy/forwarder.js
+++ b/src/proxy/forwarder.js
@@ -3,7 +3,6 @@ import { HttpsProxyAgent } from 'https-proxy-agent';
 import { createUsageTapper } from './usage-tracker.js';
 import { isOAuthRevoked } from './permission-guard.js';
 import { applyModelMap } from './model-map.js';
-import { stripThinkingBlocks } from './thinking-strip.js';
 import { resolveAggregatedProvider, rewriteModel } from './aggregated-router.js';
 
 const UPSTREAM = 'https://api.anthropic.com';
@@ -85,11 +84,14 @@ export async function forwardRequest(req, res, account, terminalId, pool, triedI
 
   let outBody = req.method !== 'GET' && req.method !== 'HEAD' ? req.rawBody : undefined;
 
-  // Always strip thinking blocks from historical assistant messages.
-  // Signatures in these blocks are HMACed per-account; our rotating pool
-  // means a replayed block from a prior turn will fail validation at a
-  // different upstream. See @/src/proxy/thinking-strip.js for detail.
-  if (outBody) outBody = stripThinkingBlocks(outBody);
+  // NOTE: We no longer strip thinking blocks. Anthropic-compatible
+  // upstreams (including DeepSeek/Kimi /anthropic endpoints) require
+  // thinking blocks to be replayed on subsequent turns. Stripping them
+  // causes a 400 "thinking must be passed back" error.
+  // The original stripping was meant to avoid signature mismatches when
+  // the OAuth pool rotates accounts between turns; that is now handled
+  // as a known limitation (sticky account selection for thinking convs).
+  // if (outBody) outBody = stripThinkingBlocks(outBody);
 
   if (isRelay || isAggregated) {
     // Relay / Aggregated station: static API key, no OAuth beta, no 1M-context stripping.

--- a/tests/account-pool.test.js
+++ b/tests/account-pool.test.js
@@ -352,3 +352,104 @@ test('markUnauthorized works without onAccountExhausted callback', async () => {
   assert.equal(pool.getAccount('acc_1').status, 'exhausted');
   // No exception thrown is the test
 });
+
+// ── Aggregated account selection ──────────────────────────────────────────
+
+function makeAggregated(id, opts = {}) {
+  return {
+    id,
+    type: 'aggregated',
+    nickname: opts.nickname ?? `agg-${id}`,
+    providers: opts.providers ?? [
+      { name: 'P1', baseUrl: 'https://p1.example.com', credentials: { apiKey: 'sk-p1' } },
+    ],
+    routing: opts.routing ?? { opus: { providerIndex: 0, model: 'model-a' } },
+    status: opts.status ?? 'idle',
+    addedAt: opts.addedAt ?? Date.now(),
+  };
+}
+
+test('aggregated account is NOT selected in auto mode when an OAuth account is available', () => {
+  const pool = new AccountPool({
+    accounts: [makeAccount('acc_oauth'), makeAggregated('acc_agg')],
+    terminals: [],
+  });
+  const acc = pool.selectAccount(makeTerminal('sk-1', 'auto'));
+  assert.equal(acc.id, 'acc_oauth');
+  assert.equal(acc.type, undefined); // OAuth has no type field
+});
+
+test('aggregated account IS selected in auto mode when all OAuth accounts are exhausted', () => {
+  const pool = new AccountPool({
+    accounts: [
+      makeAccount('acc_oauth', { status: 'exhausted' }),
+      makeAggregated('acc_agg'),
+    ],
+    terminals: [],
+  });
+  const acc = pool.selectAccount(makeTerminal('sk-1', 'auto'));
+  assert.equal(acc.id, 'acc_agg');
+  assert.equal(acc.type, 'aggregated');
+});
+
+test('aggregated account IS selected in auto mode when all OAuth accounts are cooling', () => {
+  const now = Date.now();
+  const pool = new AccountPool({
+    accounts: [
+      makeAccount('acc_oauth', { utilization: 1.0, w5hResetAt: now + 60000, w5hStatus: 'blocked' }),
+      makeAggregated('acc_agg'),
+    ],
+    terminals: [],
+  });
+  const acc = pool.selectAccount(makeTerminal('sk-1', 'auto'));
+  assert.equal(acc.id, 'acc_agg');
+});
+
+test('manual mode pins to an aggregated account when specified', () => {
+  const pool = new AccountPool({
+    accounts: [makeAccount('acc_oauth'), makeAggregated('acc_agg')],
+    terminals: [],
+  });
+  const acc = pool.selectAccount(makeTerminal('sk-1', 'manual', 'acc_agg'));
+  assert.equal(acc.id, 'acc_agg');
+  assert.equal(acc.type, 'aggregated');
+});
+
+test('exhausted aggregated accounts are not selected', () => {
+  const pool = new AccountPool({
+    accounts: [
+      makeAccount('acc_oauth', { status: 'exhausted' }),
+      makeAggregated('acc_agg', { status: 'exhausted' }),
+    ],
+    terminals: [],
+  });
+  assert.throws(
+    () => pool.selectAccount(makeTerminal('sk-1', 'auto')),
+    { message: /503/ },
+  );
+});
+
+test('selectFallback prefers aggregated over cooling OAuth', () => {
+  const now = Date.now();
+  const pool = new AccountPool({
+    accounts: [
+      makeAccount('acc_oauth', { utilization: 1.0, w5hResetAt: now + 60000, w5hStatus: 'blocked' }),
+      makeAggregated('acc_agg'),
+    ],
+    terminals: [],
+  });
+  const fb = pool.selectFallback(new Set());
+  assert.equal(fb.id, 'acc_agg');
+});
+
+test('ensureFreshToken returns aggregated account unchanged', async () => {
+  const agg = makeAggregated('acc_agg');
+  const pool = new AccountPool({
+    accounts: [agg],
+    terminals: [],
+    configStore: { readAccounts: async () => [], writeAccounts: async () => {} },
+  });
+  const result = await pool.ensureFreshToken(agg);
+  assert.equal(result.id, 'acc_agg');
+  assert.equal(result.providers?.[0]?.credentials?.apiKey, 'sk-p1');
+});

--- a/tests/aggregated-health.test.js
+++ b/tests/aggregated-health.test.js
@@ -1,0 +1,155 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { syncRelayHealth, pickProbeModel } from '../src/admin/relay-health.js';
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function makeAggregated(overrides = {}) {
+  return {
+    id: 'acc_agg_test',
+    type: 'aggregated',
+    nickname: 'Test Agg',
+    providers: overrides.providers ?? [
+      { name: 'DeepSeek', baseUrl: 'https://api.deepseek.com', credentials: { apiKey: 'sk-ds' }, probeModel: null },
+      { name: 'GLM', baseUrl: 'https://open.bigmodel.cn/api', credentials: { apiKey: 'sk-glm' }, probeModel: null },
+    ],
+    routing: overrides.routing ?? {
+      opus: { providerIndex: 0, model: 'deepseek-v4-pro' },
+      sonnet: { providerIndex: 0, model: 'deepseek-v4-pro' },
+      haiku: { providerIndex: 0, model: 'deepseek-v4-flash' },
+      image: { providerIndex: 1, model: 'glm-5v-turbo' },
+    },
+    status: 'idle',
+    ...overrides,
+  };
+}
+
+function mockFetch(responses) {
+  let idx = 0;
+  const calls = [];
+  const fn = async (url, opts) => {
+    calls.push({ url, opts });
+    const r = responses[idx++] ?? responses[responses.length - 1];
+    if (r.throw) throw r.throw;
+    return {
+      ok: r.status >= 200 && r.status < 300,
+      status: r.status,
+      json: async () => r.json ?? {},
+      text: async () => r.text ?? '',
+      headers: new Map(Object.entries(r.headers ?? {})),
+    };
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+// ── pickProbeModel for aggregated providers ───────────────────────────────
+
+function pickAggregatedProbeModel(provider, routing) {
+  if (provider.probeModel) return provider.probeModel;
+  for (const tier of ['opus', 'sonnet', 'haiku', 'image']) {
+    const route = routing?.[tier];
+    if (route && route.providerIndex != null && route.model) {
+      // provider index matching is done by caller
+      return route.model;
+    }
+  }
+  return null;
+}
+
+// ── syncRelayHealth for aggregated accounts ───────────────────────────────
+
+test('syncRelayHealth: probes each provider of an aggregated account', async () => {
+  const acc = makeAggregated({
+    providers: [
+      { name: 'DeepSeek', baseUrl: 'https://api.deepseek.com', credentials: { apiKey: 'sk-ds' }, probeModel: 'deepseek-v4-pro' },
+      { name: 'GLM', baseUrl: 'https://open.bigmodel.cn/api', credentials: { apiKey: 'sk-glm' }, probeModel: 'glm-5v-turbo' },
+    ],
+  });
+  const fetch = mockFetch([
+    { status: 200, json: { content: [{ text: 'hi' }] } },
+    { status: 200, json: { content: [{ text: 'hello' }] } },
+  ]);
+  await syncRelayHealth(acc, fetch);
+  assert.equal(acc.providers[0].health.status, 'online');
+  assert.equal(acc.providers[0].health.model, 'deepseek-v4-pro');
+  assert.equal(acc.providers[1].health.status, 'online');
+  assert.equal(acc.providers[1].health.model, 'glm-5v-turbo');
+  assert.equal(fetch.calls.length, 2);
+});
+
+test('syncRelayHealth: uses routing model when probeModel is null', async () => {
+  const acc = makeAggregated({
+    providers: [
+      { name: 'DeepSeek', baseUrl: 'https://api.deepseek.com', credentials: { apiKey: 'sk-ds' }, probeModel: null },
+    ],
+    routing: {
+      opus: { providerIndex: 0, model: 'deepseek-v4-pro' },
+    },
+  });
+  const fetch = mockFetch([{ status: 200, json: {} }]);
+  await syncRelayHealth(acc, fetch);
+  assert.equal(acc.providers[0].health.status, 'online');
+  assert.equal(acc.providers[0].health.model, 'deepseek-v4-pro');
+});
+
+test('syncRelayHealth: skips providers with no probeModel and no routing model', async () => {
+  const acc = makeAggregated({
+    providers: [
+      { name: 'DeepSeek', baseUrl: 'https://api.deepseek.com', credentials: { apiKey: 'sk-ds' }, probeModel: null },
+    ],
+    routing: {},
+  });
+  const fetch = mockFetch([{ throw: new Error('should not be called') }]);
+  await syncRelayHealth(acc, fetch);
+  assert.equal(acc.providers[0].health, undefined);
+  assert.equal(fetch.calls.length, 0);
+});
+
+test('syncRelayHealth: marks individual provider offline on HTTP error', async () => {
+  const acc = makeAggregated({
+    providers: [
+      { name: 'DeepSeek', baseUrl: 'https://api.deepseek.com', credentials: { apiKey: 'sk-ds' }, probeModel: 'deepseek-v4-pro' },
+      { name: 'GLM', baseUrl: 'https://open.bigmodel.cn/api', credentials: { apiKey: 'sk-glm' }, probeModel: 'glm-5v-turbo' },
+    ],
+  });
+  const fetch = mockFetch([
+    { status: 503, text: 'Service Unavailable' },
+    { status: 200, json: {} },
+  ]);
+  await syncRelayHealth(acc, fetch);
+  assert.equal(acc.providers[0].health.status, 'offline');
+  assert.ok(acc.providers[0].health.error.includes('503'));
+  assert.equal(acc.providers[1].health.status, 'online');
+});
+
+test('syncRelayHealth: marks individual provider offline on network error', async () => {
+  const acc = makeAggregated({
+    providers: [
+      { name: 'DeepSeek', baseUrl: 'https://api.deepseek.com', credentials: { apiKey: 'sk-ds' }, probeModel: 'deepseek-v4-pro' },
+    ],
+  });
+  const fetch = mockFetch([{ throw: new Error('ECONNREFUSED') }]);
+  await syncRelayHealth(acc, fetch);
+  assert.equal(acc.providers[0].health.status, 'offline');
+  assert.equal(acc.providers[0].health.error, 'ECONNREFUSED');
+});
+
+test('syncRelayHealth: sends correct url and headers per provider', async () => {
+  const acc = makeAggregated({
+    providers: [
+      { name: 'DeepSeek', baseUrl: 'https://api.deepseek.com', credentials: { apiKey: 'sk-ds' }, probeModel: 'deepseek-v4-pro' },
+    ],
+  });
+  const fetch = mockFetch([{ status: 200, json: {} }]);
+  await syncRelayHealth(acc, fetch);
+  assert.equal(fetch.calls[0].url, 'https://api.deepseek.com/v1/messages');
+  assert.equal(fetch.calls[0].opts.headers['x-api-key'], 'sk-ds');
+});
+
+test('syncRelayHealth: skips aggregated account with no providers', async () => {
+  const acc = makeAggregated({ providers: [] });
+  const fetch = mockFetch([{ throw: new Error('no') }]);
+  await syncRelayHealth(acc, fetch);
+  assert.equal(fetch.calls.length, 0);
+});

--- a/tests/aggregated-router.test.js
+++ b/tests/aggregated-router.test.js
@@ -1,0 +1,219 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { hasImageContent, resolveAggregatedProvider, rewriteModel } from '../src/proxy/aggregated-router.js';
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function makeAggregatedAccount(overrides = {}) {
+  return {
+    id: 'acc_agg_test',
+    type: 'aggregated',
+    nickname: 'Test Agg',
+    providers: [
+      { name: 'DeepSeek', baseUrl: 'https://api.deepseek.com', credentials: { apiKey: 'sk-ds' } },
+      { name: 'GLM', baseUrl: 'https://open.bigmodel.cn/api', credentials: { apiKey: 'sk-glm' } },
+    ],
+    routing: {
+      opus:   { providerIndex: 0, model: 'deepseek-v4-pro' },
+      sonnet: { providerIndex: 0, model: 'deepseek-v4-pro' },
+      haiku:  { providerIndex: 0, model: 'deepseek-v4-flash' },
+      image:  { providerIndex: 1, model: 'glm-5v-turbo' },
+    },
+    ...overrides,
+  };
+}
+
+// ── hasImageContent ───────────────────────────────────────────────────────
+
+test('hasImageContent: detects image in content array', () => {
+  const body = {
+    model: 'claude-opus-4-7',
+    messages: [{
+      role: 'user',
+      content: [
+        { type: 'text', text: 'look at this' },
+        { type: 'image', source: { type: 'base64', media_type: 'image/jpeg', data: 'abc' } },
+      ],
+    }],
+  };
+  assert.equal(hasImageContent(body), true);
+});
+
+test('hasImageContent: pure text content array returns false', () => {
+  const body = {
+    model: 'claude-opus-4-7',
+    messages: [{
+      role: 'user',
+      content: [
+        { type: 'text', text: 'hello' },
+        { type: 'text', text: 'world' },
+      ],
+    }],
+  };
+  assert.equal(hasImageContent(body), false);
+});
+
+test('hasImageContent: string content returns false', () => {
+  const body = {
+    model: 'claude-opus-4-7',
+    messages: [{ role: 'user', content: 'hello world' }],
+  };
+  assert.equal(hasImageContent(body), false);
+});
+
+test('hasImageContent: no messages returns false', () => {
+  const body = { model: 'claude-opus-4-7' };
+  assert.equal(hasImageContent(body), false);
+});
+
+test('hasImageContent: detects image across multiple messages', () => {
+  const body = {
+    model: 'claude-opus-4-7',
+    messages: [
+      { role: 'user', content: 'hello' },
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'see this' },
+          { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'xyz' } },
+        ],
+      },
+    ],
+  };
+  assert.equal(hasImageContent(body), true);
+});
+
+test('hasImageContent: ignores non-standard content shapes', () => {
+  const body = {
+    model: 'claude-opus-4-7',
+    messages: [{ role: 'user', content: { type: 'image' } }],
+  };
+  assert.equal(hasImageContent(body), false);
+});
+
+// ── resolveAggregatedProvider ─────────────────────────────────────────────
+
+test('resolveAggregatedProvider: opus model routes to opus config', () => {
+  const body = { model: 'claude-opus-4-7', messages: [] };
+  const acc = makeAggregatedAccount();
+  const result = resolveAggregatedProvider(body, acc);
+  assert.equal(result.baseUrl, 'https://api.deepseek.com');
+  assert.equal(result.apiKey, 'sk-ds');
+  assert.equal(result.targetModel, 'deepseek-v4-pro');
+});
+
+test('resolveAggregatedProvider: sonnet model routes to sonnet config', () => {
+  const body = { model: 'claude-sonnet-4-6', messages: [] };
+  const acc = makeAggregatedAccount();
+  const result = resolveAggregatedProvider(body, acc);
+  assert.equal(result.baseUrl, 'https://api.deepseek.com');
+  assert.equal(result.targetModel, 'deepseek-v4-pro');
+});
+
+test('resolveAggregatedProvider: haiku model routes to haiku config', () => {
+  const body = { model: 'claude-haiku-4-5-20251001', messages: [] };
+  const acc = makeAggregatedAccount();
+  const result = resolveAggregatedProvider(body, acc);
+  assert.equal(result.baseUrl, 'https://api.deepseek.com');
+  assert.equal(result.targetModel, 'deepseek-v4-flash');
+});
+
+test('resolveAggregatedProvider: image content routes to image config', () => {
+  const body = {
+    model: 'claude-opus-4-7',
+    messages: [{
+      role: 'user',
+      content: [
+        { type: 'text', text: 'look' },
+        { type: 'image', source: { type: 'base64', media_type: 'image/jpeg', data: 'abc' } },
+      ],
+    }],
+  };
+  const acc = makeAggregatedAccount();
+  const result = resolveAggregatedProvider(body, acc);
+  assert.equal(result.baseUrl, 'https://open.bigmodel.cn/api');
+  assert.equal(result.apiKey, 'sk-glm');
+  assert.equal(result.targetModel, 'glm-5v-turbo');
+});
+
+test('resolveAggregatedProvider: image falls back to opus when image routing not configured', () => {
+  const body = {
+    model: 'claude-opus-4-7',
+    messages: [{
+      role: 'user',
+      content: [
+        { type: 'image', source: { type: 'base64', media_type: 'image/jpeg', data: 'abc' } },
+      ],
+    }],
+  };
+  const acc = makeAggregatedAccount({
+    routing: {
+      opus: { providerIndex: 0, model: 'deepseek-v4-pro' },
+      sonnet: { providerIndex: 0, model: 'deepseek-v4-pro' },
+      haiku: { providerIndex: 0, model: 'deepseek-v4-flash' },
+      // image intentionally omitted
+    },
+  });
+  const result = resolveAggregatedProvider(body, acc);
+  assert.equal(result.baseUrl, 'https://api.deepseek.com');
+  assert.equal(result.targetModel, 'deepseek-v4-pro');
+});
+
+test('resolveAggregatedProvider: returns null when model prefix does not match any routing', () => {
+  const body = { model: 'gpt-4o-mini', messages: [] };
+  const acc = makeAggregatedAccount();
+  const result = resolveAggregatedProvider(body, acc);
+  assert.equal(result, null);
+});
+
+test('resolveAggregatedProvider: returns null when providerIndex is out of bounds', () => {
+  const body = { model: 'claude-opus-4-7', messages: [] };
+  const acc = makeAggregatedAccount({
+    routing: {
+      opus: { providerIndex: 99, model: 'xxx' },
+    },
+  });
+  const result = resolveAggregatedProvider(body, acc);
+  assert.equal(result, null);
+});
+
+test('resolveAggregatedProvider: returns null when account has no providers', () => {
+  const body = { model: 'claude-opus-4-7', messages: [] };
+  const acc = makeAggregatedAccount({ providers: [] });
+  const result = resolveAggregatedProvider(body, acc);
+  assert.equal(result, null);
+});
+
+test('resolveAggregatedProvider: returns null when routing is empty', () => {
+  const body = { model: 'claude-opus-4-7', messages: [] };
+  const acc = makeAggregatedAccount({ routing: {} });
+  const result = resolveAggregatedProvider(body, acc);
+  assert.equal(result, null);
+});
+
+// ── rewriteModel ──────────────────────────────────────────────────────────
+
+test('rewriteModel: replaces model name when different', () => {
+  const body = Buffer.from(JSON.stringify({ model: 'claude-opus-4-7', messages: [] }));
+  const out = rewriteModel(body, 'deepseek-v4-pro');
+  assert.equal(JSON.parse(out.toString()).model, 'deepseek-v4-pro');
+});
+
+test('rewriteModel: returns original buffer when model already matches', () => {
+  const body = Buffer.from(JSON.stringify({ model: 'deepseek-v4-pro', messages: [] }));
+  const out = rewriteModel(body, 'deepseek-v4-pro');
+  assert.equal(JSON.parse(out.toString()).model, 'deepseek-v4-pro');
+});
+
+test('rewriteModel: returns original buffer on invalid JSON', () => {
+  const body = Buffer.from('not json');
+  const out = rewriteModel(body, 'deepseek-v4-pro');
+  assert.equal(out.toString(), 'not json');
+});
+
+test('rewriteModel: returns original buffer when model field is missing', () => {
+  const body = Buffer.from(JSON.stringify({ messages: [] }));
+  const out = rewriteModel(body, 'deepseek-v4-pro');
+  const parsed = JSON.parse(out.toString());
+  assert.equal(parsed.model, undefined);
+});


### PR DESCRIPTION
## Summary
聚合卡片（Aggregated Account）允许将多个上游供应商（DeepSeek、GLM、Kimi 等）聚合到一张卡片背后，根据请求的模型自动路由到对应的供应商。

- 后端：新增 `POST /api/accounts/aggregated` API，支持多 provider 配置 + 4 层路由（opus/sonnet/haiku/image）
- Proxy：`forwardRequest` 支持 aggregated 动态路由，按模型前缀或图片内容自动选择 provider 并重写目标模型名
- Proxy：`hasImageContent` 递归检测嵌套在 `tool_result.content` 里的图片（Claude Code 实际发送的格式）
- Proxy：`account-pool.js` 修复 `mergeFromDisk` 只同步 `accessToken` 的问题，现在会同步 `routing`、`modelMap`、`providers` 等所有 admin 修改的配置
- 前端：完整的 AggregatedModal（三步向导）+ AggregatedCardBody + 路由/探测编辑器
- 前端：api.js 新增 `updateAggregatedRouting` / `updateAggregatedProbes`

## Test plan
- [x] 190 个单元测试全过
- [x] 本地验证：纯文本请求正确路由到配置的文本模型
- [x] 本地验证：带图请求正确路由到 `routing.image` 配置的多模态模型
- [x] 本地验证：修改图片路由配置后，proxy 能正确热重载新配置
- [x] 本地验证：图片路由未配置时 fallback 到 `routing.opus`

Closes #45