### PR TITLE
feat(proxy): 记录原始请求 tier 到 usage.jsonl

### DIFF
--- a/src/proxy/aggregated-router.js
+++ b/src/proxy/aggregated-router.js
@@ -36,10 +36,17 @@ export function resolveAggregatedProvider(body, account) {
   const provider = account.providers?.[route.providerIndex];
   if (!provider) return null;
 
+  const resolvedTier = hasImage ? 'image'
+    : model.startsWith('claude-opus') ? 'opus'
+    : model.startsWith('claude-sonnet') ? 'sonnet'
+    : model.startsWith('claude-haiku') ? 'haiku'
+    : 'sonnet';
+
   return {
     baseUrl: provider.baseUrl,
     apiKey: provider.credentials?.apiKey,
     targetModel: route.model,
+    resolvedTier,
   };
 }
 

--- a/src/proxy/forwarder.js
+++ b/src/proxy/forwarder.js
@@ -253,8 +253,11 @@ export async function forwardRequest(req, res, account, terminalId, pool, triedI
   // Detect SSE
   const ct = upRes.headers.get('content-type') ?? '';
   const model = isAggregated ? aggregatedProvider.targetModel : (body.model ?? 'unknown');
+  const resolvedTier = isAggregated && aggregatedProvider?.resolvedTier
+    ? aggregatedProvider.resolvedTier
+    : requestedTier;
   if (ct.includes('text/event-stream')) {
-    const tapper = createUsageTapper({ accountId: account.id, terminalId, model, tier: requestedTier });
+    const tapper = createUsageTapper({ accountId: account.id, terminalId, model, tier: resolvedTier });
     upRes.body.pipe(tapper).pipe(res);
     res.on('close', () => { if (!tapper.destroyed) tapper.destroy(); });
     upRes.body.on('error', () => res.end());
@@ -266,7 +269,7 @@ export async function forwardRequest(req, res, account, terminalId, pool, triedI
       if (json.usage) {
         const { input_tokens: inTok = 0, output_tokens: outTok = 0 } = json.usage;
         // Write via tapper helper directly
-        const tapper = createUsageTapper({ accountId: account.id, terminalId, model, tier: requestedTier });
+        const tapper = createUsageTapper({ accountId: account.id, terminalId, model, tier: resolvedTier });
         const fakeEvent = JSON.stringify({
           type: 'message_delta',
           usage: { input_tokens: inTok, output_tokens: outTok },

--- a/src/proxy/forwarder.js
+++ b/src/proxy/forwarder.js
@@ -66,11 +66,22 @@ export async function forwardRequest(req, res, account, terminalId, pool, triedI
   const isAggregated = account.type === 'aggregated';
   let aggregatedProvider = null;
 
+  // Parse body once at the top (used for tier detection and aggregated routing)
+  let body = {};
+  let requestedTier = 'sonnet';
+  try {
+    body = JSON.parse(req.rawBody?.toString() ?? '{}');
+    const model = body.model ?? '';
+    requestedTier = model.startsWith('claude-opus') ? 'opus'
+                  : model.startsWith('claude-sonnet') ? 'sonnet'
+                  : model.startsWith('claude-haiku') ? 'haiku'
+                  : 'sonnet';
+  } catch {
+    body = {};
+  }
+
   if (isAggregated) {
-    try {
-      const body = JSON.parse(req.rawBody?.toString() ?? '{}');
-      aggregatedProvider = resolveAggregatedProvider(body, account);
-    } catch { /* invalid JSON handled below */ }
+    aggregatedProvider = resolveAggregatedProvider(body, account);
     if (!aggregatedProvider) {
       return res.status(502).json({ error: 'aggregated_routing_unresolved', message: 'No provider matched for this request' });
     }
@@ -241,21 +252,21 @@ export async function forwardRequest(req, res, account, terminalId, pool, triedI
 
   // Detect SSE
   const ct = upRes.headers.get('content-type') ?? '';
-  const model = isAggregated ? aggregatedProvider.targetModel : detectModel(req);
+  const model = isAggregated ? aggregatedProvider.targetModel : (body.model ?? 'unknown');
   if (ct.includes('text/event-stream')) {
-    const tapper = createUsageTapper({ accountId: account.id, terminalId, model });
+    const tapper = createUsageTapper({ accountId: account.id, terminalId, model, tier: requestedTier });
     upRes.body.pipe(tapper).pipe(res);
     res.on('close', () => { if (!tapper.destroyed) tapper.destroy(); });
     upRes.body.on('error', () => res.end());
   } else {
-    const body = Buffer.from(await upRes.arrayBuffer());
+    const resBody = Buffer.from(await upRes.arrayBuffer());
     // Try to capture usage from JSON response
     try {
-      const json = JSON.parse(body.toString());
+      const json = JSON.parse(resBody.toString());
       if (json.usage) {
         const { input_tokens: inTok = 0, output_tokens: outTok = 0 } = json.usage;
         // Write via tapper helper directly
-        const tapper = createUsageTapper({ accountId: account.id, terminalId, model });
+        const tapper = createUsageTapper({ accountId: account.id, terminalId, model, tier: requestedTier });
         const fakeEvent = JSON.stringify({
           type: 'message_delta',
           usage: { input_tokens: inTok, output_tokens: outTok },
@@ -264,7 +275,7 @@ export async function forwardRequest(req, res, account, terminalId, pool, triedI
         tapper.resume(); // drain
       }
     } catch { /* not JSON */ }
-    res.end(body);
+    res.end(resBody);
   }
 }
 
@@ -275,11 +286,3 @@ function addOAuthBeta(existing) {
   return `${existing},${beta}`;
 }
 
-function detectModel(req) {
-  try {
-    const body = JSON.parse(req.rawBody?.toString() ?? '{}');
-    return body.model ?? 'unknown';
-  } catch {
-    return 'unknown';
-  }
-}

--- a/src/proxy/usage-tracker.js
+++ b/src/proxy/usage-tracker.js
@@ -26,7 +26,7 @@ function costPerToken(model) {
  * 2. Accumulates token counts from message_start (input) and message_delta (output),
  *    then writes one usage record per request to usage.jsonl.
  */
-export function createUsageTapper({ accountId, terminalId, model, logsDir = DEFAULT_LOGS_DIR }) {
+export function createUsageTapper({ accountId, terminalId, model, tier, logsDir = DEFAULT_LOGS_DIR }) {
   let buffer = '';
   let inTok = 0;
   let outTok = 0;
@@ -43,6 +43,7 @@ export function createUsageTapper({ accountId, terminalId, model, logsDir = DEFA
         terminalId,
         accountId,
         mdl: model,
+        tier: tier || 'sonnet',
         in: inTok,
         out: outTok,
         usd: Math.round(usd * 1e8) / 1e8,

--- a/tests/usage-tracker.test.js
+++ b/tests/usage-tracker.test.js
@@ -11,7 +11,7 @@ let dir;
 test.before(async () => { dir = await mkdtemp(join(tmpdir(), 'hub-usage-')); });
 test.after(async () => { await rm(dir, { recursive: true }); });
 
-test('parses SSE message_start + message_delta and writes usage.jsonl', async () => {
+test('parses SSE message_start + message_delta and writes usage.jsonl with tier', async () => {
   const start = {
     type: 'message_start',
     message: { usage: { input_tokens: 100 } },
@@ -27,6 +27,7 @@ test('parses SSE message_start + message_delta and writes usage.jsonl', async ()
     accountId: 'acc_1',
     terminalId: 'sk-hub-abc',
     model: 'claude-sonnet-4-6',
+    tier: 'sonnet',
     logsDir: dir,
   });
 
@@ -44,8 +45,31 @@ test('parses SSE message_start + message_delta and writes usage.jsonl', async ()
   assert.equal(record.in, 100);
   assert.equal(record.out, 50);
   assert.match(record.mdl, /sonnet/);
+  assert.equal(record.tier, 'sonnet');
   assert.ok(typeof record.ts === 'number');
   assert.ok(typeof record.usd === 'number');
+});
+
+test('defaults tier to sonnet when not provided', async () => {
+  const start = { type: 'message_start', message: { usage: { input_tokens: 10 } } };
+  const delta = { type: 'message_delta', usage: { output_tokens: 5 } };
+  const sse = `data: ${JSON.stringify(start)}\n\ndata: ${JSON.stringify(delta)}\n\n`;
+
+  const tapper = createUsageTapper({
+    accountId: 'acc_1b',
+    terminalId: 'sk-hub-def',
+    model: 'claude-opus-4-7',
+    logsDir: dir,
+  });
+
+  const source = Readable.from([Buffer.from(sse)]);
+  await pipeline(source, tapper);
+
+  const logPath = join(dir, 'acc_1b', 'usage.jsonl');
+  const lines = (await readFile(logPath, 'utf8')).trim().split('\n');
+  assert.equal(lines.length, 1);
+  const record = JSON.parse(lines[0]);
+  assert.equal(record.tier, 'sonnet');
 });
 
 test('passes chunks through unchanged', async () => {


### PR DESCRIPTION
## Summary
- `forwarder.js`: 将 body 解析提取到函数顶部，从 `body.model` 推断 tier（opus/sonnet/haiku）
- `forwarder.js`: 删除 `detectModel()`，避免重复解析 body
- `usage-tracker.js`: `createUsageTapper` 新增 `tier` 参数，写入 `usage.jsonl`
- 新增测试验证 tier 字段的写入和默认值（不传时默认 'sonnet'）

Closes #47

## Test plan
- [x] `tests/usage-tracker.test.js` 全部通过（4/4）
- [x] 完整回归测试通过（187/187）