### PR TITLE
feat(admin): 虚拟利用率计算模块（增量读取 + 内存缓存）

### DIFF
--- a/src/admin/virtual-ratelimit.js
+++ b/src/admin/virtual-ratelimit.js
@@ -1,0 +1,118 @@
+import { createReadStream } from 'node:fs';
+import { stat } from 'node:fs/promises';
+import { createInterface } from 'node:readline';
+import { join } from 'node:path';
+
+const TIER_WEIGHT = {
+  opus: 4.0,
+  sonnet: 2.0,
+  haiku: 1.0,
+  image: 3.0,
+};
+
+const LIMITS = {
+  pro: { window5h: 500_000, weekly: 5_000_000 },
+  max: { window5h: 2_500_000, weekly: 20_000_000 },
+  max_20x: { window5h: 12_500_000, weekly: 100_000_000 },
+};
+
+// 内存缓存：accountId → { lastOffset, records }
+const cache = new Map();
+
+export async function calcVirtualRateLimit(accountId, plan, logsDir) {
+  const logPath = join(logsDir, accountId, 'usage.jsonl');
+  let state = cache.get(accountId);
+  if (!state) {
+    state = { lastOffset: 0, records: [] };
+    cache.set(accountId, state);
+  }
+
+  const stats = await stat(logPath).catch(() => null);
+  if (!stats) {
+    return makeEmptyRateLimit(plan);
+  }
+
+  // 文件被截断/重建 → 全量重读
+  if (stats.size < state.lastOffset) {
+    state.lastOffset = 0;
+    state.records = [];
+  }
+
+  // 增量读取新增记录
+  if (stats.size > state.lastOffset) {
+    const newRecords = await readLinesFromOffset(logPath, state.lastOffset);
+    for (const r of newRecords) {
+      if (r && typeof r.ts === 'number') {
+        state.records.push(r);
+      }
+    }
+    state.lastOffset = stats.size;
+  }
+
+  // 清理 7 天外记录（7d 窗口最长）
+  const now = Date.now();
+  const cutoff = now - 7 * 86400_000;
+  state.records = state.records.filter(r => r.ts >= cutoff);
+
+  // 加权累加
+  let weighted5h = 0;
+  let weighted7d = 0;
+  const fiveHAgo = now - 5 * 3600_000;
+
+  for (const r of state.records) {
+    const w = TIER_WEIGHT[r.tier] ?? TIER_WEIGHT.sonnet;
+    const tokens = (r.in ?? 0) + (r.out ?? 0);
+    const weighted = tokens * w;
+    if (r.ts >= fiveHAgo) weighted5h += weighted;
+    weighted7d += weighted;
+  }
+
+  return makeRateLimit(weighted5h, weighted7d, plan, now);
+}
+
+async function readLinesFromOffset(filePath, offset) {
+  const stream = createReadStream(filePath, { start: offset });
+  const rl = createInterface({ input: stream, crlfDelay: Infinity });
+  const records = [];
+  for await (const line of rl) {
+    if (!line.trim()) continue;
+    try {
+      records.push(JSON.parse(line));
+    } catch {
+      // 跳过损坏行
+    }
+  }
+  return records;
+}
+
+function makeRateLimit(weighted5h, weighted7d, plan, now = Date.now()) {
+  const limit = LIMITS[plan] ?? LIMITS.max;
+
+  const HOUR = 3600_000;
+  const reset5h = Math.ceil(now / (5 * HOUR)) * (5 * HOUR);
+
+  const d = new Date(now);
+  const day = d.getUTCDay();
+  const daysUntilMonday = day === 0 ? 1 : 8 - day;
+  const reset7d = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + daysUntilMonday);
+
+  const util5h = weighted5h / limit.window5h;
+  const util7d = weighted7d / limit.weekly;
+
+  return {
+    window5h: {
+      utilization: util5h,
+      resetAt: reset5h,
+      status: util5h >= 1.0 ? 'blocked' : 'allowed',
+    },
+    weekly: {
+      utilization: util7d,
+      resetAt: reset7d,
+      status: util7d >= 1.0 ? 'blocked' : 'allowed',
+    },
+  };
+}
+
+function makeEmptyRateLimit(plan) {
+  return makeRateLimit(0, 0, plan);
+}

--- a/src/admin/virtual-ratelimit.js
+++ b/src/admin/virtual-ratelimit.js
@@ -61,7 +61,7 @@ export async function calcVirtualRateLimit(accountId, plan, logsDir) {
 
   for (const r of state.records) {
     const w = TIER_WEIGHT[r.tier] ?? TIER_WEIGHT.sonnet;
-    const tokens = (r.in ?? 0) + (r.out ?? 0);
+    const tokens = Math.max(0, r.in ?? 0) + Math.max(0, r.out ?? 0);
     const weighted = tokens * w;
     if (r.ts >= fiveHAgo) weighted5h += weighted;
     weighted7d += weighted;

--- a/tests/virtual-ratelimit.test.js
+++ b/tests/virtual-ratelimit.test.js
@@ -1,0 +1,170 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { calcVirtualRateLimit } from '../src/admin/virtual-ratelimit.js';
+
+let dir;
+test.before(async () => { dir = await mkdtemp(join(tmpdir(), 'hub-vrl-')); });
+test.after(async () => { await rm(dir, { recursive: true }); });
+
+async function writeUsageJsonl(accountId, records) {
+  const logDir = join(dir, accountId);
+  await mkdir(logDir, { recursive: true });
+  const lines = records.map(r => JSON.stringify(r)).join('\n') + '\n';
+  await writeFile(join(logDir, 'usage.jsonl'), lines);
+}
+
+function nowMinus(hours) {
+  return Date.now() - hours * 3600_000;
+}
+
+function next5hReset() {
+  const now = Date.now();
+  return Math.ceil(now / (5 * 3600_000)) * (5 * 3600_000);
+}
+
+function nextMondayReset() {
+  const d = new Date();
+  const day = d.getUTCDay();
+  const daysUntilMonday = day === 0 ? 1 : 8 - day;
+  return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + daysUntilMonday);
+}
+
+test('weighted utilization with different tiers', async () => {
+  const accountId = 'acc_weight';
+  await writeUsageJsonl(accountId, [
+    { ts: nowMinus(1), in: 1000, out: 500, tier: 'opus' },    // 1500 * 4.0 = 6000
+    { ts: nowMinus(2), in: 1000, out: 500, tier: 'sonnet' },  // 1500 * 2.0 = 3000
+    { ts: nowMinus(3), in: 1000, out: 500, tier: 'haiku' },   // 1500 * 1.0 = 1500
+  ]);
+
+  const rl = await calcVirtualRateLimit(accountId, 'max', dir);
+  const limit5h = 2_500_000;
+
+  assert.equal(rl.window5h.utilization, (6000 + 3000 + 1500) / limit5h);
+  assert.equal(rl.window5h.status, 'allowed');
+});
+
+test('falls back to sonnet when tier is missing', async () => {
+  const accountId = 'acc_fallback';
+  await writeUsageJsonl(accountId, [
+    { ts: nowMinus(1), in: 1000, out: 500 },  // no tier → sonnet (2.0)
+  ]);
+
+  const rl = await calcVirtualRateLimit(accountId, 'max', dir);
+  const limit5h = 2_500_000;
+  assert.equal(rl.window5h.utilization, (1500 * 2.0) / limit5h);
+});
+
+test('5h window filters correctly', async () => {
+  const accountId = 'acc_5h';
+  await writeUsageJsonl(accountId, [
+    { ts: nowMinus(3), in: 1000, out: 500, tier: 'haiku' },   // within 5h → included
+    { ts: nowMinus(6), in: 1000, out: 500, tier: 'haiku' },   // outside 5h → excluded
+  ]);
+
+  const rl = await calcVirtualRateLimit(accountId, 'max', dir);
+  const limit5h = 2_500_000;
+  assert.equal(rl.window5h.utilization, (1500 * 1.0) / limit5h);
+});
+
+test('7d window includes records up to 7 days', async () => {
+  const accountId = 'acc_7d';
+  await writeUsageJsonl(accountId, [
+    { ts: nowMinus(3), in: 1000, out: 500, tier: 'haiku' },   // within 7d → included
+    { ts: nowMinus(24 * 8), in: 1000, out: 500, tier: 'haiku' }, // outside 7d → excluded
+  ]);
+
+  const rl = await calcVirtualRateLimit(accountId, 'max', dir);
+  const limit7d = 20_000_000;
+  assert.equal(rl.weekly.utilization, (1500 * 1.0) / limit7d);
+});
+
+test('status is blocked when utilization >= 1.0', async () => {
+  const accountId = 'acc_blocked';
+  // Write enough tokens to exceed the limit
+  // PRO limit: 500K weighted. Need 500K / 1.0 = 500K tokens as haiku
+  await writeUsageJsonl(accountId, [
+    { ts: nowMinus(1), in: 500_000, out: 0, tier: 'haiku' },
+  ]);
+
+  const rl = await calcVirtualRateLimit(accountId, 'pro', dir);
+  assert.equal(rl.window5h.status, 'blocked');
+  assert.equal(rl.window5h.utilization, 1.0);
+});
+
+test('resetAt values are correct', async () => {
+  const accountId = 'acc_reset';
+  await writeUsageJsonl(accountId, [
+    { ts: nowMinus(1), in: 100, out: 50, tier: 'haiku' },
+  ]);
+
+  const rl = await calcVirtualRateLimit(accountId, 'max', dir);
+  assert.equal(rl.window5h.resetAt, next5hReset());
+  assert.equal(rl.weekly.resetAt, nextMondayReset());
+});
+
+test('handles missing usage.jsonl gracefully', async () => {
+  const accountId = 'acc_missing';
+  // Do not create usage.jsonl
+  const rl = await calcVirtualRateLimit(accountId, 'max', dir);
+  assert.equal(rl.window5h.utilization, 0);
+  assert.equal(rl.window5h.status, 'allowed');
+  assert.equal(rl.weekly.utilization, 0);
+  assert.equal(rl.weekly.status, 'allowed');
+});
+
+test('incremental read does not reprocess old records', async () => {
+  const accountId = 'acc_incremental';
+  await writeUsageJsonl(accountId, [
+    { ts: nowMinus(2), in: 100, out: 50, tier: 'haiku' },
+  ]);
+
+  // First call
+  const rl1 = await calcVirtualRateLimit(accountId, 'max', dir);
+  const util1 = rl1.window5h.utilization;
+
+  // Second call without new data → same result
+  const rl2 = await calcVirtualRateLimit(accountId, 'max', dir);
+  const util2 = rl2.window5h.utilization;
+
+  assert.equal(util1, util2);
+});
+
+test('full re-read when file is truncated', async () => {
+  const accountId = 'acc_truncated';
+  await writeUsageJsonl(accountId, [
+    { ts: nowMinus(1), in: 100, out: 50, tier: 'haiku' },
+  ]);
+
+  // First call
+  await calcVirtualRateLimit(accountId, 'max', dir);
+
+  // Truncate file (smaller content)
+  await writeUsageJsonl(accountId, [
+    { ts: nowMinus(1), in: 50, out: 25, tier: 'haiku' },
+  ]);
+
+  // Second call should detect truncation and re-read
+  const rl = await calcVirtualRateLimit(accountId, 'max', dir);
+  const limit5h = 2_500_000;
+  assert.equal(rl.window5h.utilization, (75 * 1.0) / limit5h);
+});
+
+test('different plans have different limits', async () => {
+  const accountId = 'acc_plan';
+  await writeUsageJsonl(accountId, [
+    { ts: nowMinus(1), in: 500_000, out: 0, tier: 'haiku' },
+  ]);
+
+  const rlPro = await calcVirtualRateLimit(accountId, 'pro', dir);
+  const rlMax = await calcVirtualRateLimit(accountId, 'max', dir);
+  const rlMax20x = await calcVirtualRateLimit(accountId, 'max_20x', dir);
+
+  // Same tokens, different limits → different utilization
+  assert.equal(rlPro.window5h.utilization, 500_000 / 500_000);     // 1.0 (blocked)
+  assert.equal(rlMax.window5h.utilization, 500_000 / 2_500_000);   // 0.2
+  assert.equal(rlMax20x.window5h.utilization, 500_000 / 12_500_000); // 0.04
+});


### PR DESCRIPTION
## Summary
- 新增 `src/admin/virtual-ratelimit.js`：加权利用率计算 + 增量读取 + 内存缓存
- 权重：opus 4.0x / sonnet 2.0x / haiku 1.0x / image 3.0x
- 限额：pro(500K/5M) / max(2.5M/20M) / max_20x(12.5M/100M)
- 增量读取：维护 `lastOffset`，每次只读新增记录
- 内存缓存：保留 7 天内记录，自动清理过期数据
- 新增 10 个单元测试

Closes #49

## Test plan
- [x] `tests/virtual-ratelimit.test.js` 全部通过（10/10）
- [x] 完整回归测试通过（196/196）