### PR TITLE
feat(admin): 聚合账号虚拟计量 + 等级配置 + 前端伪装 (#51)

### DIFF
--- a/src/admin/frontend/src/api.js
+++ b/src/admin/frontend/src/api.js
@@ -249,13 +249,14 @@ export async function addRelayAccount({ nickname, baseUrl, apiKey, modelMap }) {
   })
 }
 
-export async function addAggregatedAccount({ nickname, providers, routing }) {
+export async function addAggregatedAccount({ nickname, providers, routing, plan }) {
   if (USE_MOCK) {
     await delay(400)
     const newAcc = {
       id: 'acc_agg' + Date.now(),
       type: 'aggregated',
       nickname,
+      plan: plan ?? 'max',
       status: 'idle',
       hasCredentials: true,
       addedAt: Date.now(),
@@ -272,7 +273,7 @@ export async function addAggregatedAccount({ nickname, providers, routing }) {
   }
   return apiJson('/api/accounts/aggregated', {
     method: 'POST',
-    body: JSON.stringify({ nickname, providers, routing }),
+    body: JSON.stringify({ nickname, providers, routing, plan }),
   })
 }
 

--- a/src/admin/frontend/src/components/AccountsTab.jsx
+++ b/src/admin/frontend/src/components/AccountsTab.jsx
@@ -489,6 +489,7 @@ export default function AccountsTab({ accounts, terminals, onRefresh, onNewTermi
       if (acc.status === 'exhausted') return 'dot-red'
       // aggregated: check all provider healths
       if (acc.type === 'aggregated' && acc.providers) {
+        if (isRateLimited(acc)) return 'dot-red'
         const allOnline = acc.providers.every(p => !p.health || p.health.status === 'online')
         const anyOffline = acc.providers.some(p => p.health?.status === 'offline')
         if (anyOffline) return 'dot-red'
@@ -720,7 +721,7 @@ export default function AccountsTab({ accounts, terminals, onRefresh, onNewTermi
                     {/* Sync usage / health check button */}
                     <button
                       className={`card-refresh-btn${syncingId === acc.id ? ' spinning' : ''}`}
-                      title={isRelay || isAggregated ? '检测连通性' : '同步用量'}
+                      title={isRelay ? '检测连通性' : '同步用量'}
                       onClick={async e => {
                         e.stopPropagation()
                         setSyncingId(acc.id)

--- a/src/admin/frontend/src/components/AccountsTab.jsx
+++ b/src/admin/frontend/src/components/AccountsTab.jsx
@@ -702,7 +702,13 @@ export default function AccountsTab({ accounts, terminals, onRefresh, onNewTermi
                 {isRelay ? (
                   <span className="plan-badge badge-relay">中转</span>
                 ) : isAggregated ? (
-                  <span className="plan-badge badge-relay">聚合</span>
+                  isAdmin ? (
+                    <span className="plan-badge badge-relay">聚合</span>
+                  ) : (
+                    <span className={`plan-badge ${acc.plan === 'max' || acc.plan === 'max_20x' ? 'badge-max' : 'badge-pro'}`}>
+                      {acc.plan === 'max_20x' ? 'MAX 20X' : acc.plan?.toUpperCase() ?? 'MAX'}
+                    </span>
+                  )
                 ) : (
                   <span className={`plan-badge ${acc.plan === 'max' ? 'badge-max' : acc.plan === 'free' ? 'badge-free' : 'badge-pro'}`}>
                     {acc.plan?.toUpperCase() ?? 'PRO'}
@@ -746,7 +752,7 @@ export default function AccountsTab({ accounts, terminals, onRefresh, onNewTermi
                 />
               ) : isRelay ? (
                 <RelayCardBody acc={acc} mounted={mounted} terms={terms} />
-              ) : isAggregated ? (
+              ) : isAggregated && isAdmin ? (
                 <AggregatedCardBody acc={acc} mounted={mounted} terms={terms} />
               ) : (
                 <>

--- a/src/admin/frontend/src/components/AggregatedModal.jsx
+++ b/src/admin/frontend/src/components/AggregatedModal.jsx
@@ -4,6 +4,7 @@ import { addAggregatedAccount } from '../api.js'
 export default function AggregatedModal({ onClose, onSuccess }) {
   const [step, setStep] = useState(1)
   const [nickname, setNickname] = useState('')
+  const [plan, setPlan] = useState('max')
   const [providers, setProviders] = useState([{ name: '', baseUrl: '', apiKey: '', probeModel: '' }])
   const [routing, setRouting] = useState({
     opus: { providerIndex: 0, model: '' },
@@ -73,7 +74,7 @@ export default function AggregatedModal({ onClose, onSuccess }) {
           cleanRouting[key] = { providerIndex: r.providerIndex, model: r.model.trim() }
         }
       }
-      await addAggregatedAccount({ nickname: nickname.trim(), providers: cleanProviders, routing: cleanRouting })
+      await addAggregatedAccount({ nickname: nickname.trim(), providers: cleanProviders, routing: cleanRouting, plan })
       onSuccess()
     } catch (e) {
       setError(e.message || '创建失败')
@@ -97,6 +98,14 @@ export default function AggregatedModal({ onClose, onSuccess }) {
                 value={nickname}
                 onChange={e => setNickname(e.target.value)}
               />
+            </div>
+            <div className="form-row">
+              <label className="form-label">等级</label>
+              <select className="form-input" value={plan} onChange={e => setPlan(e.target.value)}>
+                <option value="pro">PRO</option>
+                <option value="max">MAX</option>
+                <option value="max_20x">MAX 20x</option>
+              </select>
             </div>
             <div className="modal-actions">
               <button className="btn btn-ghost" onClick={onClose}>取消</button>

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -15,6 +15,7 @@ import { syncRelayHealth, listRelayModels, RELAY_HEALTH_POLL_MS } from './relay-
 import { calcVirtualRateLimit } from './virtual-ratelimit.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const LOGS_DIR = join(dirname(dirname(__dirname)), 'logs');
 const PORT = process.env.ADMIN_PORT ?? 3182;
 const PROXY_INTERNAL_URL = process.env.PROXY_INTERNAL_URL ?? 'http://localhost:3180';
 const DIST_DIR = join(__dirname, 'frontend', 'dist');
@@ -133,9 +134,11 @@ app.patch('/api/accounts/:id', requireAdmin, async (req, res) => {
   }
   if (req.body.plan !== undefined && acc.type === 'aggregated') {
     const validPlans = ['pro', 'max', 'max_20x'];
-    if (validPlans.includes(req.body.plan)) {
-      acc.plan = req.body.plan;
+    if (!validPlans.includes(req.body.plan)) {
+      return res.status(400).json({ error: 'invalid_plan', message: 'plan must be one of: pro, max, max_20x' });
     }
+    acc.plan = req.body.plan;
+    acc.rateLimit = await calcVirtualRateLimit(acc.id, acc.plan, LOGS_DIR);
   }
   await configStore.writeAccounts(accounts);
   res.json(sanitiseAccount(acc));
@@ -234,7 +237,10 @@ app.post('/api/accounts/aggregated', requireAdmin, async (req, res) => {
     return res.status(400).json({ error: 'providers_required', message: 'At least one provider is required' });
   }
   const validPlans = ['pro', 'max', 'max_20x'];
-  const selectedPlan = validPlans.includes(plan) ? plan : 'max';
+  if (plan !== undefined && !validPlans.includes(plan)) {
+    return res.status(400).json({ error: 'invalid_plan', message: 'plan must be one of: pro, max, max_20x' });
+  }
+  const selectedPlan = plan ?? 'max';
   const normalisedProviders = [];
   for (const p of providers) {
     if (typeof p.name !== 'string' || p.name.trim().length === 0) {
@@ -477,9 +483,7 @@ async function syncRateLimit(acc) {
   }
   // Aggregated accounts: compute virtual rate limit from usage.jsonl.
   if (acc.type === 'aggregated') {
-    const projectRoot = dirname(fileURLToPath(new URL('../..', import.meta.url)));
-    const logsDir = join(projectRoot, 'logs');
-    acc.rateLimit = await calcVirtualRateLimit(acc.id, acc.plan ?? 'max', logsDir);
+    acc.rateLimit = await calcVirtualRateLimit(acc.id, acc.plan ?? 'max', LOGS_DIR);
     return;
   }
   try {
@@ -781,14 +785,12 @@ setInterval(syncProxyTerminals, 30_000).unref();
 async function probeAllRelays() {
   try {
     const accounts = await configStore.readAccounts();
-    const projectRoot = dirname(fileURLToPath(new URL('../..', import.meta.url)));
-    const logsDir = join(projectRoot, 'logs');
     let dirty = false;
     for (const acc of accounts) {
       if (acc.type !== 'relay' && acc.type !== 'aggregated') continue;
       if (acc.status === 'exhausted') continue;
       if (acc.type === 'aggregated') {
-        acc.rateLimit = await calcVirtualRateLimit(acc.id, acc.plan ?? 'max', logsDir);
+        acc.rateLimit = await calcVirtualRateLimit(acc.id, acc.plan ?? 'max', LOGS_DIR);
         dirty = true;
       } else {
         await probeAndCacheRelay(acc);

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -12,6 +12,7 @@ import { requireAuth, requireApproved, requireAdmin } from './auth.js';
 import { isAccountCooling, reassignCoolingTerminals } from './reassignment.js';
 import { isOAuthRevoked } from '../proxy/permission-guard.js';
 import { syncRelayHealth, listRelayModels, RELAY_HEALTH_POLL_MS } from './relay-health.js';
+import { calcVirtualRateLimit } from './virtual-ratelimit.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PORT = process.env.ADMIN_PORT ?? 3182;
@@ -130,6 +131,12 @@ app.patch('/api/accounts/:id', requireAdmin, async (req, res) => {
       }
     }
   }
+  if (req.body.plan !== undefined && acc.type === 'aggregated') {
+    const validPlans = ['pro', 'max', 'max_20x'];
+    if (validPlans.includes(req.body.plan)) {
+      acc.plan = req.body.plan;
+    }
+  }
   await configStore.writeAccounts(accounts);
   res.json(sanitiseAccount(acc));
 });
@@ -219,13 +226,15 @@ app.post('/api/accounts/relay', requireAdmin, async (req, res) => {
 // Add an aggregated routing card — multiple upstream providers behind a single
 // token, with per-tier routing (Opus/Sonnet/Haiku/Image → provider + model).
 app.post('/api/accounts/aggregated', requireAdmin, async (req, res) => {
-  const { nickname, providers, routing } = req.body ?? {};
+  const { nickname, providers, routing, plan } = req.body ?? {};
   if (typeof nickname !== 'string' || nickname.trim().length === 0) {
     return res.status(400).json({ error: 'nickname_required' });
   }
   if (!Array.isArray(providers) || providers.length === 0) {
     return res.status(400).json({ error: 'providers_required', message: 'At least one provider is required' });
   }
+  const validPlans = ['pro', 'max', 'max_20x'];
+  const selectedPlan = validPlans.includes(plan) ? plan : 'max';
   const normalisedProviders = [];
   for (const p of providers) {
     if (typeof p.name !== 'string' || p.name.trim().length === 0) {
@@ -258,6 +267,7 @@ app.post('/api/accounts/aggregated', requireAdmin, async (req, res) => {
     id: `acc_${randomBytes(6).toString('hex')}`,
     type: 'aggregated',
     nickname: nickname.trim(),
+    plan: selectedPlan,
     providers: normalisedProviders,
     routing: normalisedRouting,
     status: 'idle',
@@ -460,9 +470,16 @@ async function probeAndCacheRelay(acc) {
 }
 
 async function syncRateLimit(acc) {
-  // Relay / Aggregated accounts: probe health instead of reading Anthropic rate-limit headers.
-  if (acc.type === 'relay' || acc.type === 'aggregated') {
+  // Relay accounts: probe health instead of reading Anthropic rate-limit headers.
+  if (acc.type === 'relay') {
     await probeAndCacheRelay(acc);
+    return;
+  }
+  // Aggregated accounts: compute virtual rate limit from usage.jsonl.
+  if (acc.type === 'aggregated') {
+    const projectRoot = dirname(fileURLToPath(new URL('../..', import.meta.url)));
+    const logsDir = join(projectRoot, 'logs');
+    acc.rateLimit = await calcVirtualRateLimit(acc.id, acc.plan ?? 'max', logsDir);
     return;
   }
   try {
@@ -570,6 +587,8 @@ function sanitiseAccount(acc) {
     const hasCredentials = providers.some(p => p.hasApiKey);
     return {
       ...rest,
+      plan: acc.plan ?? 'max',
+      rateLimit: acc.rateLimit ?? null,
       providers,
       hasCredentials,
     };
@@ -762,10 +781,22 @@ setInterval(syncProxyTerminals, 30_000).unref();
 async function probeAllRelays() {
   try {
     const accounts = await configStore.readAccounts();
+    const projectRoot = dirname(fileURLToPath(new URL('../..', import.meta.url)));
+    const logsDir = join(projectRoot, 'logs');
+    let dirty = false;
     for (const acc of accounts) {
       if (acc.type !== 'relay' && acc.type !== 'aggregated') continue;
       if (acc.status === 'exhausted') continue;
-      await probeAndCacheRelay(acc);
+      if (acc.type === 'aggregated') {
+        acc.rateLimit = await calcVirtualRateLimit(acc.id, acc.plan ?? 'max', logsDir);
+        dirty = true;
+      } else {
+        await probeAndCacheRelay(acc);
+        dirty = true;
+      }
+    }
+    if (dirty) {
+      await configStore.writeAccounts(accounts);
     }
   } catch (err) {
     console.error('[relay-poll] error:', err.message);

--- a/src/admin/virtual-ratelimit.js
+++ b/src/admin/virtual-ratelimit.js
@@ -1,0 +1,18 @@
+// Stub for Issue #3. Full implementation provided by Issue #2.
+// After Issue #2 merges, this file will be replaced with the real implementation.
+
+export async function calcVirtualRateLimit(accountId, plan, logsDir) {
+  // Placeholder: returns zero utilization. Real implementation in Issue #2.
+  const now = Date.now();
+  const HOUR = 3600_000;
+  const reset5h = Math.ceil(now / (5 * HOUR)) * (5 * HOUR);
+  const d = new Date(now);
+  const day = d.getUTCDay();
+  const daysUntilMonday = day === 0 ? 1 : 8 - day;
+  const reset7d = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + daysUntilMonday);
+
+  return {
+    window5h: { utilization: 0, resetAt: reset5h, status: 'allowed' },
+    weekly: { utilization: 0, resetAt: reset7d, status: 'allowed' },
+  };
+}


### PR DESCRIPTION
## Summary
- 聚合账号接入虚拟用量计量系统（基于 usage.jsonl 加权计算）
- Admin 可配置聚合账号展示等级（PRO / MAX / MAX 20x）
- 非 admin 用户看到的聚合卡片伪装为 OAuth 订阅账号样式

## 变更详情

### Backend (`src/admin/index.js`)
- `POST /api/accounts/aggregated`: 接受 `plan` 字段，校验并持久化
- `PATCH /api/accounts/:id`: 支持修改聚合账号的 `plan`
- `syncRateLimit()`: 聚合账号调用 `calcVirtualRateLimit()` 计算虚拟利用率
- `probeAllRelays()`: 聚合账号参与 60s 周期性探测，计算并持久化虚拟 rateLimit
- `sanitiseAccount()`: 聚合账号响应包含 `plan` 和 `rateLimit`

### 新增模块 (`src/admin/virtual-ratelimit.js`)
- Stub 实现（完整实现在 Issue #2 / PR #50），接口兼容
- 返回虚拟 5h / weekly 利用率（当前恒为 0%，等 #50 合并后生效）

### Frontend
- **`AggregatedModal.jsx`**: Step 1 增加 plan 下拉选择器
- **`api.js`**: `addAggregatedAccount` 传递 `plan` 参数
- **`AccountsTab.jsx`**: 
  - 非 admin: 聚合账号 plan badge 显示 PRO/MAX/MAX 20X（不再显示"聚合"）
  - 非 admin: 卡片体走 OAuth 样式（用量条 + 终端标签），隐藏路由明细和 provider 健康
  - admin: 视角保持不变，继续显示完整路由配置和健康探测

Closes #51

## Test plan
- [x] 虚拟 rateLimit stub 接口与 #50 兼容
- [x] 创建聚合账号时 plan 字段正确传递
- [ ] 手动: 创建聚合账号后检查普通用户视角的卡片显示
- [ ] 手动: 修改 plan 后 badge 和用量限额同步更新