### PR TITLE
feat: 聚合账号虚拟 MAX 计量系统（集成 #47/#49/#51 + 验收期 fix）

### DIFF
--- a/src/admin/frontend/src/api.js
+++ b/src/admin/frontend/src/api.js
@@ -204,6 +204,19 @@ export async function updateAggregatedProbes(id, probes) {
   })
 }
 
+export async function updateAggregatedPlan(id, plan) {
+  if (USE_MOCK) {
+    await delay()
+    const acc = _accounts.find(a => a.id === id)
+    if (acc) acc.plan = plan
+    return JSON.parse(JSON.stringify(acc))
+  }
+  return apiJson(`/api/accounts/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ plan }),
+  })
+}
+
 export async function listRelayModels(id) {
   if (USE_MOCK) {
     await delay(300)

--- a/src/admin/frontend/src/api.js
+++ b/src/admin/frontend/src/api.js
@@ -249,13 +249,14 @@ export async function addRelayAccount({ nickname, baseUrl, apiKey, modelMap }) {
   })
 }
 
-export async function addAggregatedAccount({ nickname, providers, routing }) {
+export async function addAggregatedAccount({ nickname, providers, routing, plan }) {
   if (USE_MOCK) {
     await delay(400)
     const newAcc = {
       id: 'acc_agg' + Date.now(),
       type: 'aggregated',
       nickname,
+      plan: plan ?? 'max',
       status: 'idle',
       hasCredentials: true,
       addedAt: Date.now(),
@@ -272,7 +273,7 @@ export async function addAggregatedAccount({ nickname, providers, routing }) {
   }
   return apiJson('/api/accounts/aggregated', {
     method: 'POST',
-    body: JSON.stringify({ nickname, providers, routing }),
+    body: JSON.stringify({ nickname, providers, routing, plan }),
   })
 }
 

--- a/src/admin/frontend/src/components/AccountsTab.jsx
+++ b/src/admin/frontend/src/components/AccountsTab.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { updateTerminal, forceOnline, forceOffline, deleteAccount, renameAccount, refreshAccountToken, syncAccountUsage, updateRelayModelMap, updateProbeModel, listRelayModels, updateAggregatedRouting, updateAggregatedProbes } from '../api.js'
+import { updateTerminal, forceOnline, forceOffline, deleteAccount, renameAccount, refreshAccountToken, syncAccountUsage, updateRelayModelMap, updateProbeModel, listRelayModels, updateAggregatedRouting, updateAggregatedProbes, updateAggregatedPlan } from '../api.js'
 
 function fmtExpiry(ts) {
   if (!ts) return null
@@ -265,6 +265,44 @@ function AggregatedRoutingEditor({ acc, onAction }) {
 }
 
 // Inline editor for aggregated account probe models
+function AggregatedPlanEditor({ acc, onAction }) {
+  const [editing, setEditing] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [plan, setPlan] = useState(acc.plan ?? 'max')
+
+  async function save() {
+    setBusy(true)
+    try { await onAction('plan:' + plan) } finally { setBusy(false) }
+    setEditing(false)
+  }
+
+  if (!editing) {
+    const label = acc.plan === 'max_20x' ? 'MAX 20x' : (acc.plan?.toUpperCase() ?? 'MAX')
+    return (
+      <button className="action-btn" onClick={() => { setPlan(acc.plan ?? 'max'); setEditing(true) }}>
+        🏷 修改等级（当前：{label}）
+      </button>
+    )
+  }
+
+  return (
+    <div style={{ fontSize: 12, padding: '4px 0' }}>
+      <div style={{ display: 'flex', gap: 6, alignItems: 'center', marginBottom: 6 }}>
+        <span style={{ width: 80, flexShrink: 0, color: '#78716c', fontWeight: 500 }}>等级</span>
+        <select className="inline-edit" value={plan} onChange={e => setPlan(e.target.value)} style={{ flex: 1 }}>
+          <option value="pro">PRO</option>
+          <option value="max">MAX</option>
+          <option value="max_20x">MAX 20x</option>
+        </select>
+      </div>
+      <div style={{ display: 'flex', gap: 6, marginTop: 6 }}>
+        <button className="btn btn-primary btn-sm" onClick={save} disabled={busy}>{busy ? '…' : '保存'}</button>
+        <button className="btn btn-ghost btn-sm" onClick={() => setEditing(false)}>取消</button>
+      </div>
+    </div>
+  )
+}
+
 function AggregatedProbeEditor({ acc, onAction }) {
   const [editing, setEditing] = useState(false)
   const [busy, setBusy] = useState(false)
@@ -411,6 +449,9 @@ function AccountActions({ acc, onAction }) {
           🩺 设置探测模型
         </button>
       )}
+
+      {/* Aggregated plan editing */}
+      {acc.type === 'aggregated' && <AggregatedPlanEditor acc={acc} onAction={onAction} />}
 
       {/* Aggregated routing editing */}
       {acc.type === 'aggregated' && <AggregatedRoutingEditor acc={acc} onAction={onAction} />}
@@ -579,6 +620,8 @@ export default function AccountsTab({ accounts, terminals, onRefresh, onNewTermi
       await updateAggregatedRouting(acc.id, JSON.parse(action.slice(8)))
     } else if (action.startsWith('probes:')) {
       await updateAggregatedProbes(acc.id, JSON.parse(action.slice(7)))
+    } else if (action.startsWith('plan:')) {
+      await updateAggregatedPlan(acc.id, action.slice(5))
     } else if (action === 'probe-modal') {
       setProbeModalAcc(acc)
       return

--- a/src/admin/frontend/src/components/AccountsTab.jsx
+++ b/src/admin/frontend/src/components/AccountsTab.jsx
@@ -489,6 +489,7 @@ export default function AccountsTab({ accounts, terminals, onRefresh, onNewTermi
       if (acc.status === 'exhausted') return 'dot-red'
       // aggregated: check all provider healths
       if (acc.type === 'aggregated' && acc.providers) {
+        if (isRateLimited(acc)) return 'dot-red'
         const allOnline = acc.providers.every(p => !p.health || p.health.status === 'online')
         const anyOffline = acc.providers.some(p => p.health?.status === 'offline')
         if (anyOffline) return 'dot-red'
@@ -720,7 +721,7 @@ export default function AccountsTab({ accounts, terminals, onRefresh, onNewTermi
                     {/* Sync usage / health check button */}
                     <button
                       className={`card-refresh-btn${syncingId === acc.id ? ' spinning' : ''}`}
-                      title={isRelay || isAggregated ? '检测连通性' : '同步用量'}
+                      title={isRelay ? '检测连通性' : '同步用量'}
                       onClick={async e => {
                         e.stopPropagation()
                         setSyncingId(acc.id)

--- a/src/admin/frontend/src/components/AccountsTab.jsx
+++ b/src/admin/frontend/src/components/AccountsTab.jsx
@@ -702,7 +702,13 @@ export default function AccountsTab({ accounts, terminals, onRefresh, onNewTermi
                 {isRelay ? (
                   <span className="plan-badge badge-relay">中转</span>
                 ) : isAggregated ? (
-                  <span className="plan-badge badge-relay">聚合</span>
+                  isAdmin ? (
+                    <span className="plan-badge badge-relay">聚合</span>
+                  ) : (
+                    <span className={`plan-badge ${acc.plan === 'max' || acc.plan === 'max_20x' ? 'badge-max' : 'badge-pro'}`}>
+                      {acc.plan === 'max_20x' ? 'MAX 20X' : acc.plan?.toUpperCase() ?? 'MAX'}
+                    </span>
+                  )
                 ) : (
                   <span className={`plan-badge ${acc.plan === 'max' ? 'badge-max' : acc.plan === 'free' ? 'badge-free' : 'badge-pro'}`}>
                     {acc.plan?.toUpperCase() ?? 'PRO'}
@@ -746,7 +752,7 @@ export default function AccountsTab({ accounts, terminals, onRefresh, onNewTermi
                 />
               ) : isRelay ? (
                 <RelayCardBody acc={acc} mounted={mounted} terms={terms} />
-              ) : isAggregated ? (
+              ) : isAggregated && isAdmin ? (
                 <AggregatedCardBody acc={acc} mounted={mounted} terms={terms} />
               ) : (
                 <>

--- a/src/admin/frontend/src/components/AggregatedModal.jsx
+++ b/src/admin/frontend/src/components/AggregatedModal.jsx
@@ -4,6 +4,7 @@ import { addAggregatedAccount } from '../api.js'
 export default function AggregatedModal({ onClose, onSuccess }) {
   const [step, setStep] = useState(1)
   const [nickname, setNickname] = useState('')
+  const [plan, setPlan] = useState('max')
   const [providers, setProviders] = useState([{ name: '', baseUrl: '', apiKey: '', probeModel: '' }])
   const [routing, setRouting] = useState({
     opus: { providerIndex: 0, model: '' },
@@ -73,7 +74,7 @@ export default function AggregatedModal({ onClose, onSuccess }) {
           cleanRouting[key] = { providerIndex: r.providerIndex, model: r.model.trim() }
         }
       }
-      await addAggregatedAccount({ nickname: nickname.trim(), providers: cleanProviders, routing: cleanRouting })
+      await addAggregatedAccount({ nickname: nickname.trim(), providers: cleanProviders, routing: cleanRouting, plan })
       onSuccess()
     } catch (e) {
       setError(e.message || '创建失败')
@@ -97,6 +98,14 @@ export default function AggregatedModal({ onClose, onSuccess }) {
                 value={nickname}
                 onChange={e => setNickname(e.target.value)}
               />
+            </div>
+            <div className="form-row">
+              <label className="form-label">等级</label>
+              <select className="form-input" value={plan} onChange={e => setPlan(e.target.value)}>
+                <option value="pro">PRO</option>
+                <option value="max">MAX</option>
+                <option value="max_20x">MAX 20x</option>
+              </select>
             </div>
             <div className="modal-actions">
               <button className="btn btn-ghost" onClick={onClose}>取消</button>

--- a/src/admin/frontend/src/components/UsageTab.jsx
+++ b/src/admin/frontend/src/components/UsageTab.jsx
@@ -9,7 +9,10 @@ import {
 const PALETTE = ['#E87040', '#93c5fd', '#6ee7b7', '#c4b5fd', '#fde68a', '#f9a8d4', '#5eead4']
 const MODEL_COLORS = { sonnet: '#E87040', haiku: '#FDDCCC', opus: '#C0532A' }
 
-function modelKey(mdl) {
+function modelKey(mdl, tier) {
+  // tier 是 proxy 端按"原始请求的模型前缀"记录的归一化字段，
+  // 优先采用，避免聚合账号 upstream 模型名（如 kimi-for-coding）被误归到 sonnet。
+  if (tier === 'opus' || tier === 'sonnet' || tier === 'haiku') return tier
   if (!mdl) return 'unknown'
   if (mdl.includes('opus')) return 'opus'
   if (mdl.includes('haiku')) return 'haiku'
@@ -192,7 +195,7 @@ export default function UsageTab({ accounts, terminals }) {
   const donutData = useMemo(() => {
     const map = {}
     for (const r of records) {
-      const k = modelKey(r.mdl)
+      const k = modelKey(r.mdl, r.tier)
       map[k] = (map[k] ?? 0) + valueOf(r, viewMode)
     }
     return Object.entries(map).map(([k, v]) => ({ name: modelLabel(k), value: v, color: MODEL_COLORS[k] ?? '#a8a29e' }))
@@ -223,15 +226,12 @@ export default function UsageTab({ accounts, terminals }) {
     const recs = records.filter(r => groupKey(r) === selectedBreakdown)
     const map = {}
     for (const r of recs) {
-      const m = r.mdl ?? 'unknown'
-      map[m] = (map[m] ?? 0) + valueOf(r, viewMode)
+      const key = modelKey(r.mdl, r.tier)
+      map[key] = (map[key] ?? 0) + valueOf(r, viewMode)
     }
     const MODEL_ORDER = ['haiku', 'sonnet', 'opus']
     return Object.entries(map)
-      .map(([mdl, value]) => {
-        const key = modelKey(mdl)
-        return { name: modelLabel(key), value, color: MODEL_COLORS[key] ?? '#a8a29e', _order: MODEL_ORDER.indexOf(key) }
-      })
+      .map(([key, value]) => ({ name: modelLabel(key), value, color: MODEL_COLORS[key] ?? '#a8a29e', _order: MODEL_ORDER.indexOf(key) }))
       .sort((a, b) => a._order - b._order)
   }, [records, selectedBreakdown, group, viewMode])
 
@@ -250,7 +250,7 @@ export default function UsageTab({ accounts, terminals }) {
       g.inTokens += r.in ?? 0
       g.outTokens += r.out ?? 0
       g.usd += r.usd ?? 0
-      const bucket = g[modelKey(r.mdl)] ?? g.other
+      const bucket = g[modelKey(r.mdl, r.tier)] ?? g.other
       bucket.in += r.in ?? 0
       bucket.out += r.out ?? 0
     }

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -76,15 +76,13 @@ app.post('/api/accounts/:id/sync-usage', requireAdmin, async (req, res) => {
   const acc = accounts.find(a => a.id === req.params.id);
   if (!acc) return res.status(404).json({ error: 'not_found' });
   try {
-    const wasExhausted = acc.status === 'exhausted';
     await syncRateLimit(acc);
     await configStore.writeAccounts(accounts);
-    if (isAccountCooling(acc)) {
-      await reassignCoolingTerminals(acc.id, accounts, ['auto'], configStore);
-    } else if (!wasExhausted && acc.status === 'exhausted') {
-      // syncRateLimit just flipped status to exhausted (OAuth revoked);
-      // move every terminal off this account — manual included, since the
-      // account is now permanently unusable.
+    // 账号不可用（冷却 OR 永久耗尽）→ 迁走所有挂载终端，含 manual。
+    // 用户明确要求："只要账号不能用，不管是不是手动模式，底下的终端都要自动逃逸"。
+    // 旧设计 (#17) 仅迁 auto，本次升级到统一逃逸：manual pin 在不能转发的账号
+    // 上没意义，让 admin 主动迁走比让请求失败更友好。
+    if (isAccountCooling(acc) || acc.status === 'exhausted') {
       await reassignCoolingTerminals(acc.id, accounts, null, configStore);
     }
     res.json(sanitiseAccount(acc));
@@ -132,6 +130,7 @@ app.patch('/api/accounts/:id', requireAdmin, async (req, res) => {
       }
     }
   }
+  let planChanged = false;
   if (req.body.plan !== undefined && acc.type === 'aggregated') {
     const validPlans = ['pro', 'max', 'max_20x'];
     if (!validPlans.includes(req.body.plan)) {
@@ -139,8 +138,13 @@ app.patch('/api/accounts/:id', requireAdmin, async (req, res) => {
     }
     acc.plan = req.body.plan;
     acc.rateLimit = await calcVirtualRateLimit(acc.id, acc.plan, LOGS_DIR);
+    planChanged = true;
   }
   await configStore.writeAccounts(accounts);
+  // 改 plan 可能让利用率突变到 ≥100%（如 max_20x → pro）→ 迁走全部终端（含 manual）。
+  if (planChanged && isAccountCooling(acc)) {
+    await reassignCoolingTerminals(acc.id, accounts, null, configStore);
+  }
   res.json(sanitiseAccount(acc));
 });
 
@@ -675,20 +679,15 @@ async function reassignTerminals(removedAccountId, availableAccounts, modes) {
 app.post('/api/sync-usage-all', requireAdmin, async (_req, res) => {
   try {
     const accounts = await configStore.readAccounts();
-    const coolingAccs = [];
-    const revokedAccs = [];
     for (const acc of accounts) {
-      const wasExhausted = acc.status === 'exhausted';
       await syncRateLimit(acc);
-      if (isAccountCooling(acc)) coolingAccs.push(acc);
-      else if (!wasExhausted && acc.status === 'exhausted') revokedAccs.push(acc);
     }
     await configStore.writeAccounts(accounts);
-    for (const acc of coolingAccs) {
-      await reassignCoolingTerminals(acc.id, accounts, ['auto'], configStore);
-    }
-    for (const acc of revokedAccs) {
-      await reassignCoolingTerminals(acc.id, accounts, null, configStore);
+    // 不可用账号（cooling 或 exhausted）→ 迁走所有终端（含 manual）
+    for (const acc of accounts) {
+      if (acc.status === 'exhausted' || isAccountCooling(acc)) {
+        await reassignCoolingTerminals(acc.id, accounts, null, configStore);
+      }
     }
     res.json(accounts.map(sanitiseAccount));
   } catch (err) {
@@ -800,6 +799,16 @@ async function probeAllRelays() {
     }
     if (dirty) {
       await configStore.writeAccounts(accounts);
+    }
+    // 安全网：每轮无条件检查所有 cooling/exhausted 账号，把挂载在上面的
+    // 终端迁走（含 manual）。不能只在"刚进入 cooling"的瞬间触发，否则
+    //   - 重启后从磁盘读到的账号本就是 cooling，永远跳过
+    //   - 用户事后手动挂载到 cooling 账号上，永远跳过
+    // reassignCoolingTerminals 在没有匹配终端或没有温账号时是 no-op，多次调用安全。
+    for (const acc of accounts) {
+      if (acc.status === 'exhausted' || isAccountCooling(acc)) {
+        await reassignCoolingTerminals(acc.id, accounts, null, configStore);
+      }
     }
   } catch (err) {
     console.error('[relay-poll] error:', err.message);

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -791,6 +791,7 @@ async function probeAllRelays() {
       if (acc.status === 'exhausted') continue;
       if (acc.type === 'aggregated') {
         acc.rateLimit = await calcVirtualRateLimit(acc.id, acc.plan ?? 'max', LOGS_DIR);
+        await probeAndCacheRelay(acc); // 同时探测 provider 健康
         dirty = true;
       } else {
         await probeAndCacheRelay(acc);

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -15,6 +15,7 @@ import { syncRelayHealth, listRelayModels, RELAY_HEALTH_POLL_MS } from './relay-
 import { calcVirtualRateLimit } from './virtual-ratelimit.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const LOGS_DIR = join(dirname(dirname(__dirname)), 'logs');
 const PORT = process.env.ADMIN_PORT ?? 3182;
 const PROXY_INTERNAL_URL = process.env.PROXY_INTERNAL_URL ?? 'http://localhost:3180';
 const DIST_DIR = join(__dirname, 'frontend', 'dist');
@@ -133,9 +134,11 @@ app.patch('/api/accounts/:id', requireAdmin, async (req, res) => {
   }
   if (req.body.plan !== undefined && acc.type === 'aggregated') {
     const validPlans = ['pro', 'max', 'max_20x'];
-    if (validPlans.includes(req.body.plan)) {
-      acc.plan = req.body.plan;
+    if (!validPlans.includes(req.body.plan)) {
+      return res.status(400).json({ error: 'invalid_plan', message: 'plan must be one of: pro, max, max_20x' });
     }
+    acc.plan = req.body.plan;
+    acc.rateLimit = await calcVirtualRateLimit(acc.id, acc.plan, LOGS_DIR);
   }
   await configStore.writeAccounts(accounts);
   res.json(sanitiseAccount(acc));
@@ -234,7 +237,10 @@ app.post('/api/accounts/aggregated', requireAdmin, async (req, res) => {
     return res.status(400).json({ error: 'providers_required', message: 'At least one provider is required' });
   }
   const validPlans = ['pro', 'max', 'max_20x'];
-  const selectedPlan = validPlans.includes(plan) ? plan : 'max';
+  if (plan !== undefined && !validPlans.includes(plan)) {
+    return res.status(400).json({ error: 'invalid_plan', message: 'plan must be one of: pro, max, max_20x' });
+  }
+  const selectedPlan = plan ?? 'max';
   const normalisedProviders = [];
   for (const p of providers) {
     if (typeof p.name !== 'string' || p.name.trim().length === 0) {
@@ -477,9 +483,7 @@ async function syncRateLimit(acc) {
   }
   // Aggregated accounts: compute virtual rate limit from usage.jsonl.
   if (acc.type === 'aggregated') {
-    const projectRoot = dirname(fileURLToPath(new URL('../..', import.meta.url)));
-    const logsDir = join(projectRoot, 'logs');
-    acc.rateLimit = await calcVirtualRateLimit(acc.id, acc.plan ?? 'max', logsDir);
+    acc.rateLimit = await calcVirtualRateLimit(acc.id, acc.plan ?? 'max', LOGS_DIR);
     return;
   }
   try {
@@ -781,14 +785,12 @@ setInterval(syncProxyTerminals, 30_000).unref();
 async function probeAllRelays() {
   try {
     const accounts = await configStore.readAccounts();
-    const projectRoot = dirname(fileURLToPath(new URL('../..', import.meta.url)));
-    const logsDir = join(projectRoot, 'logs');
     let dirty = false;
     for (const acc of accounts) {
       if (acc.type !== 'relay' && acc.type !== 'aggregated') continue;
       if (acc.status === 'exhausted') continue;
       if (acc.type === 'aggregated') {
-        acc.rateLimit = await calcVirtualRateLimit(acc.id, acc.plan ?? 'max', logsDir);
+        acc.rateLimit = await calcVirtualRateLimit(acc.id, acc.plan ?? 'max', LOGS_DIR);
         dirty = true;
       } else {
         await probeAndCacheRelay(acc);

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -12,6 +12,7 @@ import { requireAuth, requireApproved, requireAdmin } from './auth.js';
 import { isAccountCooling, reassignCoolingTerminals } from './reassignment.js';
 import { isOAuthRevoked } from '../proxy/permission-guard.js';
 import { syncRelayHealth, listRelayModels, RELAY_HEALTH_POLL_MS } from './relay-health.js';
+import { calcVirtualRateLimit } from './virtual-ratelimit.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PORT = process.env.ADMIN_PORT ?? 3182;
@@ -130,6 +131,12 @@ app.patch('/api/accounts/:id', requireAdmin, async (req, res) => {
       }
     }
   }
+  if (req.body.plan !== undefined && acc.type === 'aggregated') {
+    const validPlans = ['pro', 'max', 'max_20x'];
+    if (validPlans.includes(req.body.plan)) {
+      acc.plan = req.body.plan;
+    }
+  }
   await configStore.writeAccounts(accounts);
   res.json(sanitiseAccount(acc));
 });
@@ -219,13 +226,15 @@ app.post('/api/accounts/relay', requireAdmin, async (req, res) => {
 // Add an aggregated routing card — multiple upstream providers behind a single
 // token, with per-tier routing (Opus/Sonnet/Haiku/Image → provider + model).
 app.post('/api/accounts/aggregated', requireAdmin, async (req, res) => {
-  const { nickname, providers, routing } = req.body ?? {};
+  const { nickname, providers, routing, plan } = req.body ?? {};
   if (typeof nickname !== 'string' || nickname.trim().length === 0) {
     return res.status(400).json({ error: 'nickname_required' });
   }
   if (!Array.isArray(providers) || providers.length === 0) {
     return res.status(400).json({ error: 'providers_required', message: 'At least one provider is required' });
   }
+  const validPlans = ['pro', 'max', 'max_20x'];
+  const selectedPlan = validPlans.includes(plan) ? plan : 'max';
   const normalisedProviders = [];
   for (const p of providers) {
     if (typeof p.name !== 'string' || p.name.trim().length === 0) {
@@ -258,6 +267,7 @@ app.post('/api/accounts/aggregated', requireAdmin, async (req, res) => {
     id: `acc_${randomBytes(6).toString('hex')}`,
     type: 'aggregated',
     nickname: nickname.trim(),
+    plan: selectedPlan,
     providers: normalisedProviders,
     routing: normalisedRouting,
     status: 'idle',
@@ -460,9 +470,16 @@ async function probeAndCacheRelay(acc) {
 }
 
 async function syncRateLimit(acc) {
-  // Relay / Aggregated accounts: probe health instead of reading Anthropic rate-limit headers.
-  if (acc.type === 'relay' || acc.type === 'aggregated') {
+  // Relay accounts: probe health instead of reading Anthropic rate-limit headers.
+  if (acc.type === 'relay') {
     await probeAndCacheRelay(acc);
+    return;
+  }
+  // Aggregated accounts: compute virtual rate limit from usage.jsonl.
+  if (acc.type === 'aggregated') {
+    const projectRoot = dirname(fileURLToPath(new URL('../..', import.meta.url)));
+    const logsDir = join(projectRoot, 'logs');
+    acc.rateLimit = await calcVirtualRateLimit(acc.id, acc.plan ?? 'max', logsDir);
     return;
   }
   try {
@@ -570,6 +587,8 @@ function sanitiseAccount(acc) {
     const hasCredentials = providers.some(p => p.hasApiKey);
     return {
       ...rest,
+      plan: acc.plan ?? 'max',
+      rateLimit: acc.rateLimit ?? null,
       providers,
       hasCredentials,
     };
@@ -762,10 +781,22 @@ setInterval(syncProxyTerminals, 30_000).unref();
 async function probeAllRelays() {
   try {
     const accounts = await configStore.readAccounts();
+    const projectRoot = dirname(fileURLToPath(new URL('../..', import.meta.url)));
+    const logsDir = join(projectRoot, 'logs');
+    let dirty = false;
     for (const acc of accounts) {
       if (acc.type !== 'relay' && acc.type !== 'aggregated') continue;
       if (acc.status === 'exhausted') continue;
-      await probeAndCacheRelay(acc);
+      if (acc.type === 'aggregated') {
+        acc.rateLimit = await calcVirtualRateLimit(acc.id, acc.plan ?? 'max', logsDir);
+        dirty = true;
+      } else {
+        await probeAndCacheRelay(acc);
+        dirty = true;
+      }
+    }
+    if (dirty) {
+      await configStore.writeAccounts(accounts);
     }
   } catch (err) {
     console.error('[relay-poll] error:', err.message);

--- a/src/admin/reassignment.js
+++ b/src/admin/reassignment.js
@@ -1,9 +1,13 @@
 /**
  * Server-side mirror of the proxy's cooling detection + terminal
- * reassignment helpers. Used by admin sync-usage endpoints to
- * proactively move auto-mode terminals off accounts that have just
- * entered cooldown, without waiting for the next request to trigger
- * a 429 + fallback on the proxy side.
+ * reassignment helpers. Used by admin sync-usage endpoints and
+ * probeAllRelays to proactively move terminals off unusable accounts
+ * (cooling OR exhausted), without waiting for the next request to
+ * trigger a 429 + fallback on the proxy side.
+ *
+ * Per user requirement: 终端逃逸应忽略 mode —— manual pin 在不能转发
+ * 的账号上没意义，让 admin 主动迁走比让请求失败更友好。callers 应
+ * 传 modes=null（全部迁），保留 ['auto'] 仅供历史路径使用。
  */
 
 export function isWindowCooling(w) {

--- a/src/admin/virtual-ratelimit.js
+++ b/src/admin/virtual-ratelimit.js
@@ -67,22 +67,30 @@ async function doCalc(accountId, plan, logsDir) {
     state.lastOffset = stats.size;
   }
 
-  // 清理 7 天外记录（7d 窗口最长）
+  // 用固定窗口而非滑动窗口（与 Anthropic 官方计量 + UI 显示的 resetAt 边界对齐）：
+  //   5h 窗口 = [上一个 UTC 对齐的 5h 边界, now]
+  //   7d 窗口 = [上一个周一 00:00 UTC, now]
+  // 滑动窗口会让记录在 reset 后仍计入，跟"reset 后归零"的预期不符。
   const now = Date.now();
-  const cutoff = now - 7 * 86400_000;
-  state.records = state.records.filter(r => r.ts >= cutoff);
+  const HOUR = 3600_000;
+  const fiveHStart = Math.floor(now / (5 * HOUR)) * (5 * HOUR);
+  const dNow = new Date(now);
+  const dayNow = dNow.getUTCDay();
+  const daysSinceMonday = (dayNow + 6) % 7; // Sun=0→6, Mon=1→0, …, Sat=6→5
+  const weekStart = Date.UTC(dNow.getUTCFullYear(), dNow.getUTCMonth(), dNow.getUTCDate() - daysSinceMonday);
+
+  // 清理早于 7d 窗口起点的记录（永远不再被任何窗口需要）
+  state.records = state.records.filter(r => r.ts >= weekStart);
 
   // 加权累加
   let weighted5h = 0;
   let weighted7d = 0;
-  const fiveHAgo = now - 5 * 3600_000;
-
   for (const r of state.records) {
     const w = TIER_WEIGHT[r.tier] ?? TIER_WEIGHT.sonnet;
     const tokens = Math.max(0, r.in ?? 0) + Math.max(0, r.out ?? 0);
     const weighted = tokens * w;
-    if (r.ts >= fiveHAgo) weighted5h += weighted;
-    weighted7d += weighted;
+    if (r.ts >= fiveHStart) weighted5h += weighted;
+    if (r.ts >= weekStart) weighted7d += weighted;
   }
 
   return makeRateLimit(weighted5h, weighted7d, plan, now);

--- a/src/admin/virtual-ratelimit.js
+++ b/src/admin/virtual-ratelimit.js
@@ -1,0 +1,118 @@
+import { createReadStream } from 'node:fs';
+import { stat } from 'node:fs/promises';
+import { createInterface } from 'node:readline';
+import { join } from 'node:path';
+
+const TIER_WEIGHT = {
+  opus: 4.0,
+  sonnet: 2.0,
+  haiku: 1.0,
+  image: 3.0,
+};
+
+const LIMITS = {
+  pro: { window5h: 500_000, weekly: 5_000_000 },
+  max: { window5h: 2_500_000, weekly: 20_000_000 },
+  max_20x: { window5h: 12_500_000, weekly: 100_000_000 },
+};
+
+// 内存缓存：accountId → { lastOffset, records }
+const cache = new Map();
+
+export async function calcVirtualRateLimit(accountId, plan, logsDir) {
+  const logPath = join(logsDir, accountId, 'usage.jsonl');
+  let state = cache.get(accountId);
+  if (!state) {
+    state = { lastOffset: 0, records: [] };
+    cache.set(accountId, state);
+  }
+
+  const stats = await stat(logPath).catch(() => null);
+  if (!stats) {
+    return makeEmptyRateLimit(plan);
+  }
+
+  // 文件被截断/重建 → 全量重读
+  if (stats.size < state.lastOffset) {
+    state.lastOffset = 0;
+    state.records = [];
+  }
+
+  // 增量读取新增记录
+  if (stats.size > state.lastOffset) {
+    const newRecords = await readLinesFromOffset(logPath, state.lastOffset);
+    for (const r of newRecords) {
+      if (r && typeof r.ts === 'number') {
+        state.records.push(r);
+      }
+    }
+    state.lastOffset = stats.size;
+  }
+
+  // 清理 7 天外记录（7d 窗口最长）
+  const now = Date.now();
+  const cutoff = now - 7 * 86400_000;
+  state.records = state.records.filter(r => r.ts >= cutoff);
+
+  // 加权累加
+  let weighted5h = 0;
+  let weighted7d = 0;
+  const fiveHAgo = now - 5 * 3600_000;
+
+  for (const r of state.records) {
+    const w = TIER_WEIGHT[r.tier] ?? TIER_WEIGHT.sonnet;
+    const tokens = (r.in ?? 0) + (r.out ?? 0);
+    const weighted = tokens * w;
+    if (r.ts >= fiveHAgo) weighted5h += weighted;
+    weighted7d += weighted;
+  }
+
+  return makeRateLimit(weighted5h, weighted7d, plan, now);
+}
+
+async function readLinesFromOffset(filePath, offset) {
+  const stream = createReadStream(filePath, { start: offset });
+  const rl = createInterface({ input: stream, crlfDelay: Infinity });
+  const records = [];
+  for await (const line of rl) {
+    if (!line.trim()) continue;
+    try {
+      records.push(JSON.parse(line));
+    } catch {
+      // 跳过损坏行
+    }
+  }
+  return records;
+}
+
+function makeRateLimit(weighted5h, weighted7d, plan, now = Date.now()) {
+  const limit = LIMITS[plan] ?? LIMITS.max;
+
+  const HOUR = 3600_000;
+  const reset5h = Math.ceil(now / (5 * HOUR)) * (5 * HOUR);
+
+  const d = new Date(now);
+  const day = d.getUTCDay();
+  const daysUntilMonday = day === 0 ? 1 : 8 - day;
+  const reset7d = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + daysUntilMonday);
+
+  const util5h = weighted5h / limit.window5h;
+  const util7d = weighted7d / limit.weekly;
+
+  return {
+    window5h: {
+      utilization: util5h,
+      resetAt: reset5h,
+      status: util5h >= 1.0 ? 'blocked' : 'allowed',
+    },
+    weekly: {
+      utilization: util7d,
+      resetAt: reset7d,
+      status: util7d >= 1.0 ? 'blocked' : 'allowed',
+    },
+  };
+}
+
+function makeEmptyRateLimit(plan) {
+  return makeRateLimit(0, 0, plan);
+}

--- a/src/admin/virtual-ratelimit.js
+++ b/src/admin/virtual-ratelimit.js
@@ -19,7 +19,25 @@ const LIMITS = {
 // 内存缓存：accountId → { lastOffset, records }
 const cache = new Map();
 
+// 按 accountId 串行化的 promise 队列。
+// 防止 probeAllRelays / 手动 sync / /api/sync-usage-all 并发调用导致：
+//   两个 caller 拿到相同的 lastOffset → 都从同一 offset 读取 → 各自把同一批
+//   新记录 push 进 state.records → 利用率被翻倍。
+const queues = new Map();
+
 export async function calcVirtualRateLimit(accountId, plan, logsDir) {
+  const prev = queues.get(accountId) ?? Promise.resolve();
+  const next = prev.catch(() => {}).then(() => doCalc(accountId, plan, logsDir));
+  queues.set(accountId, next);
+  try {
+    return await next;
+  } finally {
+    // 仅在本次仍是队尾时清理，避免覆盖后续排队的 promise
+    if (queues.get(accountId) === next) queues.delete(accountId);
+  }
+}
+
+async function doCalc(accountId, plan, logsDir) {
   const logPath = join(logsDir, accountId, 'usage.jsonl');
   let state = cache.get(accountId);
   if (!state) {

--- a/src/admin/virtual-ratelimit.js
+++ b/src/admin/virtual-ratelimit.js
@@ -1,0 +1,18 @@
+// Stub for Issue #3. Full implementation provided by Issue #2.
+// After Issue #2 merges, this file will be replaced with the real implementation.
+
+export async function calcVirtualRateLimit(accountId, plan, logsDir) {
+  // Placeholder: returns zero utilization. Real implementation in Issue #2.
+  const now = Date.now();
+  const HOUR = 3600_000;
+  const reset5h = Math.ceil(now / (5 * HOUR)) * (5 * HOUR);
+  const d = new Date(now);
+  const day = d.getUTCDay();
+  const daysUntilMonday = day === 0 ? 1 : 8 - day;
+  const reset7d = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + daysUntilMonday);
+
+  return {
+    window5h: { utilization: 0, resetAt: reset5h, status: 'allowed' },
+    weekly: { utilization: 0, resetAt: reset7d, status: 'allowed' },
+  };
+}

--- a/src/admin/virtual-ratelimit.js
+++ b/src/admin/virtual-ratelimit.js
@@ -61,7 +61,7 @@ export async function calcVirtualRateLimit(accountId, plan, logsDir) {
 
   for (const r of state.records) {
     const w = TIER_WEIGHT[r.tier] ?? TIER_WEIGHT.sonnet;
-    const tokens = (r.in ?? 0) + (r.out ?? 0);
+    const tokens = Math.max(0, r.in ?? 0) + Math.max(0, r.out ?? 0);
     const weighted = tokens * w;
     if (r.ts >= fiveHAgo) weighted5h += weighted;
     weighted7d += weighted;

--- a/src/proxy/account-pool.js
+++ b/src/proxy/account-pool.js
@@ -199,8 +199,6 @@ export class AccountPool {
     if (!cb.canRequest()) throw new Error('503: account circuit breaker open');
     // 账号不可用（exhausted / cooling 含聚合虚拟限额）→ 不让 manual pin
     // 把请求送到必然失败的账号上；先尝试 fallback 到温账号，找不到再 503。
-    // admin 的 reassignCoolingTerminals 会把终端从 cooling 账号迁走，但
-    // 60s 轮询窗口内可能错过；这里是 proxy 层的兜底。
     if (acc.status === 'exhausted' || this.#isCooling(acc)) {
       const alt = this.selectFallback(new Set([accountId]));
       if (!alt) throw new Error('503: pinned account unavailable and no warm alternative');
@@ -331,9 +329,14 @@ export class AccountPool {
         for (const freshAcc of fresh) {
           const mem = this.#accounts.find(a => a.id === freshAcc.id);
           if (mem) {
-            // Preserve in-memory runtime state (fresher than disk)
-            const preservedRateLimit = mem.rateLimit;
-            const preservedCooldown = mem.cooldownUntil;
+            // OAuth: in-memory rateLimit/cooldown 来自 Anthropic 响应头，比磁盘新；
+            //   admin 探测虽偶尔更新磁盘，但仍可能落后于实时响应头。
+            // Aggregated/Relay: rateLimit 是 admin 端虚拟计算/探测的产物，proxy
+            //   自己从来不更新它（不接收上游限额头）。此时磁盘永远是"权威源"，
+            //   保留内存反而会丢弃 admin 的最新计算（如 5h 边界过后的归零）。
+            const isRelayLike = mem.type === 'relay' || mem.type === 'aggregated';
+            const preservedRateLimit = isRelayLike ? null : mem.rateLimit;
+            const preservedCooldown = isRelayLike ? null : mem.cooldownUntil;
             const preservedHealth = mem.health;
             const preservedProviderHealths = mem.type === 'aggregated' && Array.isArray(mem.providers)
               ? mem.providers.map(p => p.health)
@@ -342,9 +345,9 @@ export class AccountPool {
             // Full replace from disk
             Object.assign(mem, freshAcc);
 
-            // Restore preserved state
-            mem.rateLimit = preservedRateLimit;
-            mem.cooldownUntil = preservedCooldown;
+            // Restore preserved state — OAuth only
+            if (preservedRateLimit !== null) mem.rateLimit = preservedRateLimit;
+            if (preservedCooldown !== null) mem.cooldownUntil = preservedCooldown;
             mem.health = preservedHealth;
             if (Array.isArray(mem.providers) && preservedProviderHealths.length) {
               for (let i = 0; i < Math.min(mem.providers.length, preservedProviderHealths.length); i++) {

--- a/src/proxy/account-pool.js
+++ b/src/proxy/account-pool.js
@@ -92,9 +92,11 @@ export class AccountPool {
     const oauth = eligible.filter(a => !isRelay(a));
     const warm = oauth.filter(a => !this.#isCooling(a));
     if (warm.length) return this.#leastUtilized(warm);
-    const relays = eligible.filter(isRelay);
+    // relay/aggregated 也要过滤 cooling —— 聚合账号的虚拟限额到顶时（admin 设的
+    // 策略闸门），上游虽能转发但用户希望被识别为不可用，此时不应当兜底到它上。
+    const relays = eligible.filter(a => isRelay(a) && !this.#isCooling(a));
     if (relays.length) return this.#oldestRelay(relays);
-    const cooling = oauth.filter(a => this.#isCooling(a));
+    const cooling = eligible.filter(a => this.#isCooling(a));
     if (cooling.length) return this.#soonestReset(cooling);
     return null;
   }
@@ -195,6 +197,15 @@ export class AccountPool {
     if (!acc) throw new Error('503: account not found');
     const cb = this.#ensureCB(accountId);
     if (!cb.canRequest()) throw new Error('503: account circuit breaker open');
+    // 账号不可用（exhausted / cooling 含聚合虚拟限额）→ 不让 manual pin
+    // 把请求送到必然失败的账号上；先尝试 fallback 到温账号，找不到再 503。
+    // admin 的 reassignCoolingTerminals 会把终端从 cooling 账号迁走，但
+    // 60s 轮询窗口内可能错过；这里是 proxy 层的兜底。
+    if (acc.status === 'exhausted' || this.#isCooling(acc)) {
+      const alt = this.selectFallback(new Set([accountId]));
+      if (!alt) throw new Error('503: pinned account unavailable and no warm alternative');
+      return alt;
+    }
     return acc;
   }
 

--- a/src/proxy/aggregated-router.js
+++ b/src/proxy/aggregated-router.js
@@ -36,10 +36,17 @@ export function resolveAggregatedProvider(body, account) {
   const provider = account.providers?.[route.providerIndex];
   if (!provider) return null;
 
+  const resolvedTier = hasImage ? 'image'
+    : model.startsWith('claude-opus') ? 'opus'
+    : model.startsWith('claude-sonnet') ? 'sonnet'
+    : model.startsWith('claude-haiku') ? 'haiku'
+    : 'sonnet';
+
   return {
     baseUrl: provider.baseUrl,
     apiKey: provider.credentials?.apiKey,
     targetModel: route.model,
+    resolvedTier,
   };
 }
 

--- a/src/proxy/aggregated-router.js
+++ b/src/proxy/aggregated-router.js
@@ -20,12 +20,12 @@ export function hasImageContent(body) {
 
 export function resolveAggregatedProvider(body, account) {
   const hasImage = hasImageContent(body);
+  const model = body.model ?? '';
   let route;
 
   if (hasImage) {
     route = account.routing?.image ?? account.routing?.opus;
   } else {
-    const model = body.model ?? '';
     if (model.startsWith('claude-opus')) route = account.routing?.opus;
     else if (model.startsWith('claude-sonnet')) route = account.routing?.sonnet;
     else if (model.startsWith('claude-haiku')) route = account.routing?.haiku;

--- a/src/proxy/forwarder.js
+++ b/src/proxy/forwarder.js
@@ -253,8 +253,11 @@ export async function forwardRequest(req, res, account, terminalId, pool, triedI
   // Detect SSE
   const ct = upRes.headers.get('content-type') ?? '';
   const model = isAggregated ? aggregatedProvider.targetModel : (body.model ?? 'unknown');
+  const resolvedTier = isAggregated && aggregatedProvider?.resolvedTier
+    ? aggregatedProvider.resolvedTier
+    : requestedTier;
   if (ct.includes('text/event-stream')) {
-    const tapper = createUsageTapper({ accountId: account.id, terminalId, model, tier: requestedTier });
+    const tapper = createUsageTapper({ accountId: account.id, terminalId, model, tier: resolvedTier });
     upRes.body.pipe(tapper).pipe(res);
     res.on('close', () => { if (!tapper.destroyed) tapper.destroy(); });
     upRes.body.on('error', () => res.end());
@@ -266,7 +269,7 @@ export async function forwardRequest(req, res, account, terminalId, pool, triedI
       if (json.usage) {
         const { input_tokens: inTok = 0, output_tokens: outTok = 0 } = json.usage;
         // Write via tapper helper directly
-        const tapper = createUsageTapper({ accountId: account.id, terminalId, model, tier: requestedTier });
+        const tapper = createUsageTapper({ accountId: account.id, terminalId, model, tier: resolvedTier });
         const fakeEvent = JSON.stringify({
           type: 'message_delta',
           usage: { input_tokens: inTok, output_tokens: outTok },

--- a/src/proxy/forwarder.js
+++ b/src/proxy/forwarder.js
@@ -66,11 +66,22 @@ export async function forwardRequest(req, res, account, terminalId, pool, triedI
   const isAggregated = account.type === 'aggregated';
   let aggregatedProvider = null;
 
+  // Parse body once at the top (used for tier detection and aggregated routing)
+  let body = {};
+  let requestedTier = 'sonnet';
+  try {
+    body = JSON.parse(req.rawBody?.toString() ?? '{}');
+    const model = body.model ?? '';
+    requestedTier = model.startsWith('claude-opus') ? 'opus'
+                  : model.startsWith('claude-sonnet') ? 'sonnet'
+                  : model.startsWith('claude-haiku') ? 'haiku'
+                  : 'sonnet';
+  } catch {
+    body = {};
+  }
+
   if (isAggregated) {
-    try {
-      const body = JSON.parse(req.rawBody?.toString() ?? '{}');
-      aggregatedProvider = resolveAggregatedProvider(body, account);
-    } catch { /* invalid JSON handled below */ }
+    aggregatedProvider = resolveAggregatedProvider(body, account);
     if (!aggregatedProvider) {
       return res.status(502).json({ error: 'aggregated_routing_unresolved', message: 'No provider matched for this request' });
     }
@@ -241,21 +252,21 @@ export async function forwardRequest(req, res, account, terminalId, pool, triedI
 
   // Detect SSE
   const ct = upRes.headers.get('content-type') ?? '';
-  const model = isAggregated ? aggregatedProvider.targetModel : detectModel(req);
+  const model = isAggregated ? aggregatedProvider.targetModel : (body.model ?? 'unknown');
   if (ct.includes('text/event-stream')) {
-    const tapper = createUsageTapper({ accountId: account.id, terminalId, model });
+    const tapper = createUsageTapper({ accountId: account.id, terminalId, model, tier: requestedTier });
     upRes.body.pipe(tapper).pipe(res);
     res.on('close', () => { if (!tapper.destroyed) tapper.destroy(); });
     upRes.body.on('error', () => res.end());
   } else {
-    const body = Buffer.from(await upRes.arrayBuffer());
+    const resBody = Buffer.from(await upRes.arrayBuffer());
     // Try to capture usage from JSON response
     try {
-      const json = JSON.parse(body.toString());
+      const json = JSON.parse(resBody.toString());
       if (json.usage) {
         const { input_tokens: inTok = 0, output_tokens: outTok = 0 } = json.usage;
         // Write via tapper helper directly
-        const tapper = createUsageTapper({ accountId: account.id, terminalId, model });
+        const tapper = createUsageTapper({ accountId: account.id, terminalId, model, tier: requestedTier });
         const fakeEvent = JSON.stringify({
           type: 'message_delta',
           usage: { input_tokens: inTok, output_tokens: outTok },
@@ -264,7 +275,7 @@ export async function forwardRequest(req, res, account, terminalId, pool, triedI
         tapper.resume(); // drain
       }
     } catch { /* not JSON */ }
-    res.end(body);
+    res.end(resBody);
   }
 }
 
@@ -275,11 +286,3 @@ function addOAuthBeta(existing) {
   return `${existing},${beta}`;
 }
 
-function detectModel(req) {
-  try {
-    const body = JSON.parse(req.rawBody?.toString() ?? '{}');
-    return body.model ?? 'unknown';
-  } catch {
-    return 'unknown';
-  }
-}

--- a/src/proxy/usage-tracker.js
+++ b/src/proxy/usage-tracker.js
@@ -26,7 +26,7 @@ function costPerToken(model) {
  * 2. Accumulates token counts from message_start (input) and message_delta (output),
  *    then writes one usage record per request to usage.jsonl.
  */
-export function createUsageTapper({ accountId, terminalId, model, logsDir = DEFAULT_LOGS_DIR }) {
+export function createUsageTapper({ accountId, terminalId, model, tier, logsDir = DEFAULT_LOGS_DIR }) {
   let buffer = '';
   let inTok = 0;
   let outTok = 0;
@@ -43,6 +43,7 @@ export function createUsageTapper({ accountId, terminalId, model, logsDir = DEFA
         terminalId,
         accountId,
         mdl: model,
+        tier: tier || 'sonnet',
         in: inTok,
         out: outTok,
         usd: Math.round(usd * 1e8) / 1e8,

--- a/src/proxy/usage-tracker.js
+++ b/src/proxy/usage-tracker.js
@@ -61,9 +61,10 @@ export function createUsageTapper({ accountId, terminalId, model, tier, logsDir 
       buffer = lines.pop();
 
       for (const line of lines) {
-        if (!line.startsWith('data: ')) continue;
+        if (!line.startsWith('data:')) continue;
+        const payload = line[5] === ' ' ? line.slice(6) : line.slice(5);
         try {
-          const event = JSON.parse(line.slice(6));
+          const event = JSON.parse(payload);
           if (event.type === 'message_start' && event.message?.usage) {
             inTok += event.message.usage.input_tokens ?? 0;
           }

--- a/tests/account-pool.test.js
+++ b/tests/account-pool.test.js
@@ -453,3 +453,62 @@ test('ensureFreshToken returns aggregated account unchanged', async () => {
   assert.equal(result.id, 'acc_agg');
   assert.equal(result.providers?.[0]?.credentials?.apiKey, 'sk-p1');
 });
+
+// ── Manual mode escapes cooling pin (Bug C) ───────────────────────────────
+
+test('manual mode with cooling aggregated pin falls back to warm OAuth', () => {
+  const now = Date.now();
+  const cool = makeAggregated('acc_agg_cool');
+  cool.rateLimit = {
+    window5h: { utilization: 1.5, resetAt: now + 60_000, status: 'blocked' },
+    weekly:   { utilization: 0.3, resetAt: now + 86_400_000, status: 'allowed' },
+  };
+  const pool = new AccountPool({
+    accounts: [cool, makeAccount('acc_warm')],
+    terminals: [],
+  });
+  const acc = pool.selectAccount(makeTerminal('sk-1', 'manual', 'acc_agg_cool'));
+  assert.notEqual(acc.id, 'acc_agg_cool');
+  assert.equal(acc.id, 'acc_warm');
+});
+
+test('manual mode with cooling OAuth pin falls back to aggregated', () => {
+  const now = Date.now();
+  const pool = new AccountPool({
+    accounts: [
+      makeAccount('acc_oauth_cool', { utilization: 1.0, w5hResetAt: now + 60_000, w5hStatus: 'blocked' }),
+      makeAggregated('acc_agg'),
+    ],
+    terminals: [],
+  });
+  const acc = pool.selectAccount(makeTerminal('sk-1', 'manual', 'acc_oauth_cool'));
+  assert.equal(acc.id, 'acc_agg');
+});
+
+test('manual mode with exhausted pin throws when no alternative exists', () => {
+  const pool = new AccountPool({
+    accounts: [makeAccount('acc_only', { status: 'exhausted' })],
+    terminals: [],
+  });
+  assert.throws(
+    () => pool.selectAccount(makeTerminal('sk-1', 'manual', 'acc_only')),
+    /503/,
+  );
+});
+
+test('selectFallback skips cooling aggregated account', () => {
+  const now = Date.now();
+  const cool = makeAggregated('acc_agg_cool');
+  cool.rateLimit = {
+    window5h: { utilization: 2.0, resetAt: now + 60_000, status: 'blocked' },
+    weekly:   { utilization: 0.3, resetAt: now + 86_400_000, status: 'allowed' },
+  };
+  const warm = makeAggregated('acc_agg_warm');
+  warm.addedAt = now - 1000; // 更老 → oldestRelay 优先
+  const pool = new AccountPool({
+    accounts: [cool, warm],
+    terminals: [],
+  });
+  const fb = pool.selectFallback(new Set());
+  assert.equal(fb.id, 'acc_agg_warm');
+});

--- a/tests/admin-reassignment.test.js
+++ b/tests/admin-reassignment.test.js
@@ -141,3 +141,19 @@ test('reassignCoolingTerminals: no-op when no affected terminals', async () => {
   await reassignCoolingTerminals('acc_cool', accounts, ['auto'], store);
   assert.equal(store.state.terminals[0].accountId, before);
 });
+
+test('reassignCoolingTerminals: modes=null moves manual terminals too', async () => {
+  // Per user requirement: 账号不可用时所有终端都要逃逸，不分 mode。
+  // sync-usage / probeAllRelays 路径都用 null 调用，必须把 manual 也迁。
+  const accounts = [
+    makeAccount('acc_cool', { utilization: 1.0 }),
+    makeAccount('acc_warm', { utilization: 0.1 }),
+  ];
+  const store = makeStore([
+    makeTerminal('t_manual', 'manual', 'acc_cool'),
+    makeTerminal('t_auto',   'auto',   'acc_cool'),
+  ]);
+  await reassignCoolingTerminals('acc_cool', accounts, null, store);
+  assert.equal(store.state.terminals.find(t => t.id === 't_manual').accountId, 'acc_warm');
+  assert.equal(store.state.terminals.find(t => t.id === 't_auto').accountId,   'acc_warm');
+});

--- a/tests/usage-tracker.test.js
+++ b/tests/usage-tracker.test.js
@@ -11,7 +11,7 @@ let dir;
 test.before(async () => { dir = await mkdtemp(join(tmpdir(), 'hub-usage-')); });
 test.after(async () => { await rm(dir, { recursive: true }); });
 
-test('parses SSE message_start + message_delta and writes usage.jsonl', async () => {
+test('parses SSE message_start + message_delta and writes usage.jsonl with tier', async () => {
   const start = {
     type: 'message_start',
     message: { usage: { input_tokens: 100 } },
@@ -27,6 +27,7 @@ test('parses SSE message_start + message_delta and writes usage.jsonl', async ()
     accountId: 'acc_1',
     terminalId: 'sk-hub-abc',
     model: 'claude-sonnet-4-6',
+    tier: 'sonnet',
     logsDir: dir,
   });
 
@@ -44,8 +45,31 @@ test('parses SSE message_start + message_delta and writes usage.jsonl', async ()
   assert.equal(record.in, 100);
   assert.equal(record.out, 50);
   assert.match(record.mdl, /sonnet/);
+  assert.equal(record.tier, 'sonnet');
   assert.ok(typeof record.ts === 'number');
   assert.ok(typeof record.usd === 'number');
+});
+
+test('defaults tier to sonnet when not provided', async () => {
+  const start = { type: 'message_start', message: { usage: { input_tokens: 10 } } };
+  const delta = { type: 'message_delta', usage: { output_tokens: 5 } };
+  const sse = `data: ${JSON.stringify(start)}\n\ndata: ${JSON.stringify(delta)}\n\n`;
+
+  const tapper = createUsageTapper({
+    accountId: 'acc_1b',
+    terminalId: 'sk-hub-def',
+    model: 'claude-opus-4-7',
+    logsDir: dir,
+  });
+
+  const source = Readable.from([Buffer.from(sse)]);
+  await pipeline(source, tapper);
+
+  const logPath = join(dir, 'acc_1b', 'usage.jsonl');
+  const lines = (await readFile(logPath, 'utf8')).trim().split('\n');
+  assert.equal(lines.length, 1);
+  const record = JSON.parse(lines[0]);
+  assert.equal(record.tier, 'sonnet');
 });
 
 test('passes chunks through unchanged', async () => {

--- a/tests/usage-tracker.test.js
+++ b/tests/usage-tracker.test.js
@@ -88,6 +88,33 @@ test('passes chunks through unchanged', async () => {
   assert.equal(chunks.join(''), sse);
 });
 
+test('parses SSE without space after data: colon (DeepSeek/Kimi format)', async () => {
+  const start = { type: 'message_start', message: { usage: { input_tokens: 77 } } };
+  const delta = { type: 'message_delta', usage: { output_tokens: 33 } };
+  // Note: no space after "data:" — some Anthropic-compatible relays emit this format.
+  const sse = `event:message_start\ndata:${JSON.stringify(start)}\n\nevent:message_delta\ndata:${JSON.stringify(delta)}\n\n`;
+
+  const tapper = createUsageTapper({
+    accountId: 'acc_nospace',
+    terminalId: 'sk-hub-kimi',
+    model: 'kimi-for-coding',
+    tier: 'sonnet',
+    logsDir: dir,
+  });
+
+  const source = Readable.from([Buffer.from(sse)]);
+  await pipeline(source, tapper, async function*(stream) {
+    for await (const _ of stream) { /* drain */ }
+  });
+
+  const logPath = join(dir, 'acc_nospace', 'usage.jsonl');
+  const lines = (await readFile(logPath, 'utf8')).trim().split('\n');
+  assert.equal(lines.length, 1);
+  const record = JSON.parse(lines[0]);
+  assert.equal(record.in, 77);
+  assert.equal(record.out, 33);
+});
+
 test('writes usage on close even if flush is not called (client disconnect)', async () => {
   const start = { type: 'message_start', message: { usage: { input_tokens: 200 } } };
   const delta = { type: 'message_delta', usage: { output_tokens: 80 } };

--- a/tests/virtual-ratelimit.test.js
+++ b/tests/virtual-ratelimit.test.js
@@ -168,3 +168,20 @@ test('different plans have different limits', async () => {
   assert.equal(rlMax.window5h.utilization, 500_000 / 2_500_000);   // 0.2
   assert.equal(rlMax20x.window5h.utilization, 500_000 / 12_500_000); // 0.04
 });
+
+test('concurrent calcs do not double-count records (race condition)', async () => {
+  const accountId = 'acc_race';
+  await writeUsageJsonl(accountId, [
+    { ts: nowMinus(1), in: 100_000, out: 50_000, tier: 'sonnet' }, // 150k * 2.0 = 300k weighted
+  ]);
+
+  // 触发 10 个并发调用，模拟 probeAllRelays + 手动 sync + sync-usage-all 同时打过来
+  const results = await Promise.all(
+    Array.from({ length: 10 }, () => calcVirtualRateLimit(accountId, 'max', dir))
+  );
+
+  // 全部应得到一致的 0.12（300k / 2.5M），任何一次出现 >0.12 即说明有重复累加
+  for (const rl of results) {
+    assert.equal(rl.window5h.utilization, 300_000 / 2_500_000);
+  }
+});

--- a/tests/virtual-ratelimit.test.js
+++ b/tests/virtual-ratelimit.test.js
@@ -16,8 +16,27 @@ async function writeUsageJsonl(accountId, records) {
   await writeFile(join(logDir, 'usage.jsonl'), lines);
 }
 
-function nowMinus(hours) {
-  return Date.now() - hours * 3600_000;
+// 固定窗口语义下的时间戳辅助：
+//   inBucket()  → 当前 5h 桶 + 当前周内的安全时间戳（NOW - 1s 兜底到桶起点）
+//   before5h() → 上一个 5h 桶（同一周内）→ 7d 计入但 5h 不计入
+//   beforeWeek() → 当前周起点之前 → 两个窗口都不计入
+const FIVE_H = 5 * 3600_000;
+const NOW_REF = Date.now();
+const BUCKET_START_REF = Math.floor(NOW_REF / FIVE_H) * FIVE_H;
+const dRef = new Date(NOW_REF);
+const daysSinceMondayRef = (dRef.getUTCDay() + 6) % 7;
+const WEEK_START_REF = Date.UTC(dRef.getUTCFullYear(), dRef.getUTCMonth(), dRef.getUTCDate() - daysSinceMondayRef);
+
+function inBucket() {
+  // 总是在当前 5h 桶内（bucket_start + 60s，给桶刚开始的边缘情况留余量）
+  return BUCKET_START_REF + 60_000;
+}
+function before5h() {
+  // 上一个 5h 桶内：先确保不早于本周起点（边缘 case：周一 00:00 UTC）
+  return Math.max(BUCKET_START_REF - 60_000, WEEK_START_REF + 60_000);
+}
+function beforeWeek() {
+  return WEEK_START_REF - 60_000;
 }
 
 function next5hReset() {
@@ -35,9 +54,9 @@ function nextMondayReset() {
 test('weighted utilization with different tiers', async () => {
   const accountId = 'acc_weight';
   await writeUsageJsonl(accountId, [
-    { ts: nowMinus(1), in: 1000, out: 500, tier: 'opus' },    // 1500 * 4.0 = 6000
-    { ts: nowMinus(2), in: 1000, out: 500, tier: 'sonnet' },  // 1500 * 2.0 = 3000
-    { ts: nowMinus(3), in: 1000, out: 500, tier: 'haiku' },   // 1500 * 1.0 = 1500
+    { ts: inBucket(), in: 1000, out: 500, tier: 'opus' },    // 1500 * 4.0 = 6000
+    { ts: inBucket(), in: 1000, out: 500, tier: 'sonnet' },  // 1500 * 2.0 = 3000
+    { ts: inBucket(), in: 1000, out: 500, tier: 'haiku' },   // 1500 * 1.0 = 1500
   ]);
 
   const rl = await calcVirtualRateLimit(accountId, 'max', dir);
@@ -50,7 +69,7 @@ test('weighted utilization with different tiers', async () => {
 test('falls back to sonnet when tier is missing', async () => {
   const accountId = 'acc_fallback';
   await writeUsageJsonl(accountId, [
-    { ts: nowMinus(1), in: 1000, out: 500 },  // no tier → sonnet (2.0)
+    { ts: inBucket(), in: 1000, out: 500 },  // no tier → sonnet (2.0)
   ]);
 
   const rl = await calcVirtualRateLimit(accountId, 'max', dir);
@@ -61,8 +80,8 @@ test('falls back to sonnet when tier is missing', async () => {
 test('5h window filters correctly', async () => {
   const accountId = 'acc_5h';
   await writeUsageJsonl(accountId, [
-    { ts: nowMinus(3), in: 1000, out: 500, tier: 'haiku' },   // within 5h → included
-    { ts: nowMinus(6), in: 1000, out: 500, tier: 'haiku' },   // outside 5h → excluded
+    { ts: inBucket(),   in: 1000, out: 500, tier: 'haiku' },  // within 5h → included
+    { ts: before5h(),   in: 1000, out: 500, tier: 'haiku' },  // outside 5h, in week → excluded from 5h, included in 7d
   ]);
 
   const rl = await calcVirtualRateLimit(accountId, 'max', dir);
@@ -73,8 +92,8 @@ test('5h window filters correctly', async () => {
 test('7d window includes records up to 7 days', async () => {
   const accountId = 'acc_7d';
   await writeUsageJsonl(accountId, [
-    { ts: nowMinus(3), in: 1000, out: 500, tier: 'haiku' },   // within 7d → included
-    { ts: nowMinus(24 * 8), in: 1000, out: 500, tier: 'haiku' }, // outside 7d → excluded
+    { ts: inBucket(),   in: 1000, out: 500, tier: 'haiku' },  // within current week → included in 7d
+    { ts: beforeWeek(), in: 1000, out: 500, tier: 'haiku' },  // before week start → excluded
   ]);
 
   const rl = await calcVirtualRateLimit(accountId, 'max', dir);
@@ -87,7 +106,7 @@ test('status is blocked when utilization >= 1.0', async () => {
   // Write enough tokens to exceed the limit
   // PRO limit: 500K weighted. Need 500K / 1.0 = 500K tokens as haiku
   await writeUsageJsonl(accountId, [
-    { ts: nowMinus(1), in: 500_000, out: 0, tier: 'haiku' },
+    { ts: inBucket(), in: 500_000, out: 0, tier: 'haiku' },
   ]);
 
   const rl = await calcVirtualRateLimit(accountId, 'pro', dir);
@@ -98,7 +117,7 @@ test('status is blocked when utilization >= 1.0', async () => {
 test('resetAt values are correct', async () => {
   const accountId = 'acc_reset';
   await writeUsageJsonl(accountId, [
-    { ts: nowMinus(1), in: 100, out: 50, tier: 'haiku' },
+    { ts: inBucket(), in: 100, out: 50, tier: 'haiku' },
   ]);
 
   const rl = await calcVirtualRateLimit(accountId, 'max', dir);
@@ -119,7 +138,7 @@ test('handles missing usage.jsonl gracefully', async () => {
 test('incremental read does not reprocess old records', async () => {
   const accountId = 'acc_incremental';
   await writeUsageJsonl(accountId, [
-    { ts: nowMinus(2), in: 100, out: 50, tier: 'haiku' },
+    { ts: inBucket(), in: 100, out: 50, tier: 'haiku' },
   ]);
 
   // First call
@@ -136,7 +155,7 @@ test('incremental read does not reprocess old records', async () => {
 test('full re-read when file is truncated', async () => {
   const accountId = 'acc_truncated';
   await writeUsageJsonl(accountId, [
-    { ts: nowMinus(1), in: 100, out: 50, tier: 'haiku' },
+    { ts: inBucket(), in: 100, out: 50, tier: 'haiku' },
   ]);
 
   // First call
@@ -144,7 +163,7 @@ test('full re-read when file is truncated', async () => {
 
   // Truncate file (smaller content)
   await writeUsageJsonl(accountId, [
-    { ts: nowMinus(1), in: 50, out: 25, tier: 'haiku' },
+    { ts: inBucket(), in: 50, out: 25, tier: 'haiku' },
   ]);
 
   // Second call should detect truncation and re-read
@@ -156,7 +175,7 @@ test('full re-read when file is truncated', async () => {
 test('different plans have different limits', async () => {
   const accountId = 'acc_plan';
   await writeUsageJsonl(accountId, [
-    { ts: nowMinus(1), in: 500_000, out: 0, tier: 'haiku' },
+    { ts: inBucket(), in: 500_000, out: 0, tier: 'haiku' },
   ]);
 
   const rlPro = await calcVirtualRateLimit(accountId, 'pro', dir);
@@ -172,7 +191,7 @@ test('different plans have different limits', async () => {
 test('concurrent calcs do not double-count records (race condition)', async () => {
   const accountId = 'acc_race';
   await writeUsageJsonl(accountId, [
-    { ts: nowMinus(1), in: 100_000, out: 50_000, tier: 'sonnet' }, // 150k * 2.0 = 300k weighted
+    { ts: inBucket(), in: 100_000, out: 50_000, tier: 'sonnet' }, // 150k * 2.0 = 300k weighted
   ]);
 
   // 触发 10 个并发调用，模拟 probeAllRelays + 手动 sync + sync-usage-all 同时打过来
@@ -184,4 +203,19 @@ test('concurrent calcs do not double-count records (race condition)', async () =
   for (const rl of results) {
     assert.equal(rl.window5h.utilization, 300_000 / 2_500_000);
   }
+});
+
+test('fixed window: records before last 5h boundary are excluded (post-reset)', async () => {
+  // 关键回归：用户报的"时间到了用量没重置"。before5h() 在上一个 5h 桶内，
+  // 固定窗口语义下应当不计入当前 5h 利用率。
+  const accountId = 'acc_post_reset';
+  await writeUsageJsonl(accountId, [
+    { ts: before5h(), in: 1_000_000, out: 0, tier: 'opus' }, // 4M weighted, 上一桶
+  ]);
+
+  const rl = await calcVirtualRateLimit(accountId, 'max', dir);
+  assert.equal(rl.window5h.utilization, 0);
+  assert.equal(rl.window5h.status, 'allowed');
+  // 7d 应仍包含（同一周内）
+  assert.ok(rl.weekly.utilization > 0);
 });

--- a/tests/virtual-ratelimit.test.js
+++ b/tests/virtual-ratelimit.test.js
@@ -1,0 +1,170 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { calcVirtualRateLimit } from '../src/admin/virtual-ratelimit.js';
+
+let dir;
+test.before(async () => { dir = await mkdtemp(join(tmpdir(), 'hub-vrl-')); });
+test.after(async () => { await rm(dir, { recursive: true }); });
+
+async function writeUsageJsonl(accountId, records) {
+  const logDir = join(dir, accountId);
+  await mkdir(logDir, { recursive: true });
+  const lines = records.map(r => JSON.stringify(r)).join('\n') + '\n';
+  await writeFile(join(logDir, 'usage.jsonl'), lines);
+}
+
+function nowMinus(hours) {
+  return Date.now() - hours * 3600_000;
+}
+
+function next5hReset() {
+  const now = Date.now();
+  return Math.ceil(now / (5 * 3600_000)) * (5 * 3600_000);
+}
+
+function nextMondayReset() {
+  const d = new Date();
+  const day = d.getUTCDay();
+  const daysUntilMonday = day === 0 ? 1 : 8 - day;
+  return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + daysUntilMonday);
+}
+
+test('weighted utilization with different tiers', async () => {
+  const accountId = 'acc_weight';
+  await writeUsageJsonl(accountId, [
+    { ts: nowMinus(1), in: 1000, out: 500, tier: 'opus' },    // 1500 * 4.0 = 6000
+    { ts: nowMinus(2), in: 1000, out: 500, tier: 'sonnet' },  // 1500 * 2.0 = 3000
+    { ts: nowMinus(3), in: 1000, out: 500, tier: 'haiku' },   // 1500 * 1.0 = 1500
+  ]);
+
+  const rl = await calcVirtualRateLimit(accountId, 'max', dir);
+  const limit5h = 2_500_000;
+
+  assert.equal(rl.window5h.utilization, (6000 + 3000 + 1500) / limit5h);
+  assert.equal(rl.window5h.status, 'allowed');
+});
+
+test('falls back to sonnet when tier is missing', async () => {
+  const accountId = 'acc_fallback';
+  await writeUsageJsonl(accountId, [
+    { ts: nowMinus(1), in: 1000, out: 500 },  // no tier → sonnet (2.0)
+  ]);
+
+  const rl = await calcVirtualRateLimit(accountId, 'max', dir);
+  const limit5h = 2_500_000;
+  assert.equal(rl.window5h.utilization, (1500 * 2.0) / limit5h);
+});
+
+test('5h window filters correctly', async () => {
+  const accountId = 'acc_5h';
+  await writeUsageJsonl(accountId, [
+    { ts: nowMinus(3), in: 1000, out: 500, tier: 'haiku' },   // within 5h → included
+    { ts: nowMinus(6), in: 1000, out: 500, tier: 'haiku' },   // outside 5h → excluded
+  ]);
+
+  const rl = await calcVirtualRateLimit(accountId, 'max', dir);
+  const limit5h = 2_500_000;
+  assert.equal(rl.window5h.utilization, (1500 * 1.0) / limit5h);
+});
+
+test('7d window includes records up to 7 days', async () => {
+  const accountId = 'acc_7d';
+  await writeUsageJsonl(accountId, [
+    { ts: nowMinus(3), in: 1000, out: 500, tier: 'haiku' },   // within 7d → included
+    { ts: nowMinus(24 * 8), in: 1000, out: 500, tier: 'haiku' }, // outside 7d → excluded
+  ]);
+
+  const rl = await calcVirtualRateLimit(accountId, 'max', dir);
+  const limit7d = 20_000_000;
+  assert.equal(rl.weekly.utilization, (1500 * 1.0) / limit7d);
+});
+
+test('status is blocked when utilization >= 1.0', async () => {
+  const accountId = 'acc_blocked';
+  // Write enough tokens to exceed the limit
+  // PRO limit: 500K weighted. Need 500K / 1.0 = 500K tokens as haiku
+  await writeUsageJsonl(accountId, [
+    { ts: nowMinus(1), in: 500_000, out: 0, tier: 'haiku' },
+  ]);
+
+  const rl = await calcVirtualRateLimit(accountId, 'pro', dir);
+  assert.equal(rl.window5h.status, 'blocked');
+  assert.equal(rl.window5h.utilization, 1.0);
+});
+
+test('resetAt values are correct', async () => {
+  const accountId = 'acc_reset';
+  await writeUsageJsonl(accountId, [
+    { ts: nowMinus(1), in: 100, out: 50, tier: 'haiku' },
+  ]);
+
+  const rl = await calcVirtualRateLimit(accountId, 'max', dir);
+  assert.equal(rl.window5h.resetAt, next5hReset());
+  assert.equal(rl.weekly.resetAt, nextMondayReset());
+});
+
+test('handles missing usage.jsonl gracefully', async () => {
+  const accountId = 'acc_missing';
+  // Do not create usage.jsonl
+  const rl = await calcVirtualRateLimit(accountId, 'max', dir);
+  assert.equal(rl.window5h.utilization, 0);
+  assert.equal(rl.window5h.status, 'allowed');
+  assert.equal(rl.weekly.utilization, 0);
+  assert.equal(rl.weekly.status, 'allowed');
+});
+
+test('incremental read does not reprocess old records', async () => {
+  const accountId = 'acc_incremental';
+  await writeUsageJsonl(accountId, [
+    { ts: nowMinus(2), in: 100, out: 50, tier: 'haiku' },
+  ]);
+
+  // First call
+  const rl1 = await calcVirtualRateLimit(accountId, 'max', dir);
+  const util1 = rl1.window5h.utilization;
+
+  // Second call without new data → same result
+  const rl2 = await calcVirtualRateLimit(accountId, 'max', dir);
+  const util2 = rl2.window5h.utilization;
+
+  assert.equal(util1, util2);
+});
+
+test('full re-read when file is truncated', async () => {
+  const accountId = 'acc_truncated';
+  await writeUsageJsonl(accountId, [
+    { ts: nowMinus(1), in: 100, out: 50, tier: 'haiku' },
+  ]);
+
+  // First call
+  await calcVirtualRateLimit(accountId, 'max', dir);
+
+  // Truncate file (smaller content)
+  await writeUsageJsonl(accountId, [
+    { ts: nowMinus(1), in: 50, out: 25, tier: 'haiku' },
+  ]);
+
+  // Second call should detect truncation and re-read
+  const rl = await calcVirtualRateLimit(accountId, 'max', dir);
+  const limit5h = 2_500_000;
+  assert.equal(rl.window5h.utilization, (75 * 1.0) / limit5h);
+});
+
+test('different plans have different limits', async () => {
+  const accountId = 'acc_plan';
+  await writeUsageJsonl(accountId, [
+    { ts: nowMinus(1), in: 500_000, out: 0, tier: 'haiku' },
+  ]);
+
+  const rlPro = await calcVirtualRateLimit(accountId, 'pro', dir);
+  const rlMax = await calcVirtualRateLimit(accountId, 'max', dir);
+  const rlMax20x = await calcVirtualRateLimit(accountId, 'max_20x', dir);
+
+  // Same tokens, different limits → different utilization
+  assert.equal(rlPro.window5h.utilization, 500_000 / 500_000);     // 1.0 (blocked)
+  assert.equal(rlMax.window5h.utilization, 500_000 / 2_500_000);   // 0.2
+  assert.equal(rlMax20x.window5h.utilization, 500_000 / 12_500_000); // 0.04
+});


### PR DESCRIPTION
## Summary

集成原 3 个 PR (#48 / #50 / #52，对应 issues #47/#49/#51) + 验收联调阶段发现的一系列 bug 修复。一次端到端验收通过后整体合并。

### 三个原始功能

- **#47 / PR #48** — proxy 在 usage.jsonl 记录归一化 tier（按原始请求模型前缀）
- **#49 / PR #50** — admin 虚拟利用率计算模块（增量读取 + 内存缓存 + 加权累加）
- **#51 / PR #52** — admin 接入虚拟计量、聚合账号 plan 配置、前端非 admin 用户伪装视图

### 验收期 fix（按提交顺序）

| Commit | 问题 |
|---|---|
| `41df1f3` | aggregated-router.js `model` 块级作用域导致 ReferenceError，所有非图片聚合请求转发失败 |
| `467a1c7` | 图片请求记录的 tier 错（应为 image，被记成 sonnet） |
| `1657407` | PRD 对齐：非法 plan 返回 400、PATCH 后重算 rateLimit、statusDot 检查虚拟限额 |
| `2f47c17` | 负数 in/out token 按 0 处理 |
| `7f05d82` | SSE 解析兼容 `data:{...}`（冒号后无空格的 DeepSeek/Kimi 格式）→ 修聚合账号用量统计完全不记录 |
| `13fe6f6` | 加聚合账号 plan 编辑入口（创建后无法修改） |
| `960a879` | 用量图表按 tier 分类（聚合账号 mdl=kimi-for-coding 被错归为 Sonnet） |
| `70a176a` | virtual-ratelimit 按 accountId 串行化（防并发重复累加） |
| `0dd2121` | 不可用账号下**所有**终端无条件逃逸（含 manual + 已 cooling 状态）+ proxy `#pickManual`/`selectFallback` 兜底 cooling |
| `7727af1` | 虚拟计量改固定窗口（与 UI resetAt 对齐，5h 边界过后真正归零）+ proxy `mergeFromDisk` 对聚合账号信任磁盘 |

### 验收 checklist（全部通过）

- [x] 创建聚合账号 + plan 选择（PRO / MAX / MAX 20x）
- [x] plan 编辑（创建后修改）
- [x] 虚拟计量记录 tier，按 tier 加权
- [x] 用量图表按 tier 正确分类（不再误归 Sonnet）
- [x] 非 admin 用户看到 OAuth 风格伪装卡片（隐藏 provider 健康/路由）
- [x] 用量耗尽 → 状态点变红、所有终端（含 manual）自动逃逸
- [x] 5h 固定窗口边界过后利用率归零
- [x] proxy 拒绝把请求转发给 cooling 账号（manual pin 也兜底）
- [x] 边界：不传 plan 默认 MAX、非法 plan 返回 400、空 jsonl 返回 0%、force-offline 红点

## Test plan

- [x] `npm test` — 205 项全过
- [x] 端到端：用 Claude Code 终端打到聚合账号，观察用量条/卡片状态/终端迁移行为均符合预期
- [x] 5h 固定窗口边界过后归零
- [x] 并发 calc 不重复累加（10 个并行回归测试）
- [x] manual pin 在 cooling 账号上自动 fallback 到 warm 账号

## Closes

Closes #47, #49, #51（原始 issue）
Supersedes #48, #50, #52（开发期 PR，整合到本 PR）