### PR TITLE
docs(guide): rename env var, add EFFORT_LEVEL, skip-onboarding step

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Once logged in as admin:
 
 ```bash
 export ANTHROPIC_BASE_URL=http://127.0.0.1:3180
-export ANTHROPIC_API_KEY=sk-hub-...   # the key from step 2
+export ANTHROPIC_AUTH_TOKEN=sk-hub-...   # the key from step 2
 claude
 ```
 
@@ -192,6 +192,6 @@ logs/             # Usage logs per account (gitignored)
 
 ## TODO
 
-- [ ] Scheduled backup for `config/` (hourly tar.gz snapshots, 7-day retention). `terminals.json` is painful to restore since every user would need to update their `ANTHROPIC_API_KEY`.
+- [ ] Scheduled backup for `config/` (hourly tar.gz snapshots, 7-day retention). `terminals.json` is painful to restore since every user would need to update their `ANTHROPIC_AUTH_TOKEN`.
 - [ ] Custom SMTP in Supabase (e.g. [Resend](https://resend.com/)) to escape the free-tier 2-emails-per-hour limit before onboarding real users.
 - [x] Clean up legacy terminals with no `userId` — they show as "（无主）" for admins; decide whether to claim them or delete.

--- a/docs/scrum-with-ai/sprints/2026-04-27-W18/standup-log.md
+++ b/docs/scrum-with-ai/sprints/2026-04-27-W18/standup-log.md
@@ -112,3 +112,41 @@ rebuild + 更新 Caddyfile + reload + 改 Supabase Site URL 即可生效。
 - 主线: 走 product-requirement-first 起 admin-restyle PRD（标"很重要"）
 - 看心情: 补 #58 风格尾巴（tab logo / 配色细节）
 - 仍 blocked: 无
+
+## 2026-05-06 (Wed) · Sprint Day 10/14
+> 写入时间：2026-05-06T10:12:37+08:00 · sprint=2026-04-27-W18
+
+### Yesterday
+- 计划（来自 04-30 entry Today + Tomorrow's seed）:
+  - #58 营销首页实施（issue-first-dev 整套）
+  - 04-30 收盘后：起 admin-restyle PRD + 补 #58 风格尾巴
+  - #56 / #40 / #57 暂缓
+- 实际:
+  - 04-30: #58 PR #60 merged @ 19:39（marketing/ Next.js 15 主体；顺手 close #59）+ ad-hoc cleanup（cookie domain `97defa5` / install.sh 修复 `5326685` / README 三子域 `1f4f7de` / 14+11 stale 分支清理）
+  - 04-30 EOD 22:13 lock，commit `44650ad`
+  - 05-01 → 05-05: 五一假期，no significant change（git/gh 校验：0 commit / 0 PR / 0 issue closed）
+  - 05-05: 用户使用时发现 OAuth token 已过期未自动刷新 → bug 浮出（5/2-5/4 无流量未暴露）
+- 差距:
+  - 04-30 计划只列 #58，实际还做了 cookie domain / README / install.sh / 分支清理一堆 ad-hoc，颗粒度仍偏粗
+  - admin-restyle PRD 因假期未起，今天也未排（继续往后挪）
+  - **新发现 latent bug**：OAuth token 自动刷新失效，需 root cause 排查
+
+### Today
+- **#40 中转站 thinking signature bug**（sprint committed P2，今天收）
+- **#57 优化用户使用指南**（sprint committed，今天收）
+- **[P0 ad-hoc] OAuth token 自动刷新失效**：先快速排查 root cause（开发产生的 bug？Claude Code 刷新机制变了？其他？）→ 再决定要不要立 issue 走流程
+- 与 sprint goal 关系: #40 / #57 on-goal（committed scope）；OAuth bug 是 ad-hoc 介入（紧急 latent bug，5/5 用户暴露），暂不计入 sprint commits 待 root cause 后判
+- ⏸ 推迟: admin-restyle PRD（PO 标"很重要"但今天排不下）；#58 风格尾巴；#56 充值模块（仍 0 进度）
+
+### Blockers
+- 无
+
+### Realignment (L1)
+- trigger: 5/5 用户发现 OAuth token 过期未自动刷新；5/2-5/4 五一假期无流量，bug 在假期前已存在但未被发现
+- decision: 今天优先 #40 + #57（兑现 sprint commit）；OAuth bug 先排查 root cause 不立刻立 issue —— 排查产物决定下一步走向（developer-introduced bug → 立 P0 issue 走 issue-first-dev；upstream 协议变化 → 立 issue + 标 upstream-tracking；其他原因 → 视情况判）
+- 同步到: 暂不动 sprint-plan.md committed[]；root cause 明确后若需立 issue，再考虑是否拉进本 sprint 或推到下 sprint backlog
+
+### Sprint Goal Progress
+- 状态: at-risk
+- 理由（用户原话）: 充值模块 0 进度，剩 4 天起步偏紧
+

--- a/src/admin/frontend/src/components/GuideTab.jsx
+++ b/src/admin/frontend/src/components/GuideTab.jsx
@@ -35,15 +35,17 @@ function EnvVarsBlock({ token = 'sk-hub-xxx', shell }) {
   if (shell === 'powershell') {
     return (
       <CodeBlock code={`[System.Environment]::SetEnvironmentVariable("ANTHROPIC_BASE_URL", "https://api.hub.tertax.cn", "User")
-[System.Environment]::SetEnvironmentVariable("ANTHROPIC_API_KEY", "${token}", "User")
-[System.Environment]::SetEnvironmentVariable("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "1", "User")`} />
+[System.Environment]::SetEnvironmentVariable("ANTHROPIC_AUTH_TOKEN", "${token}", "User")
+[System.Environment]::SetEnvironmentVariable("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "1", "User")
+[System.Environment]::SetEnvironmentVariable("CLAUDE_CODE_EFFORT_LEVEL", "max", "User")`} />
     )
   }
   const rc = shell === 'zsh' ? '~/.zshrc' : shell === 'bash_profile' ? '~/.bash_profile' : '~/.bashrc'
   return (
     <CodeBlock code={`echo 'export ANTHROPIC_BASE_URL="https://api.hub.tertax.cn"' >> ${rc}
-echo 'export ANTHROPIC_API_KEY="${token}"' >> ${rc}
+echo 'export ANTHROPIC_AUTH_TOKEN="${token}"' >> ${rc}
 echo 'export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1' >> ${rc}
+echo 'export CLAUDE_CODE_EFFORT_LEVEL=max' >> ${rc}
 source ${rc}`} />
   )
 }
@@ -79,20 +81,30 @@ function WindowsGuide() {
         <Note>遇到权限错误？确认以管理员身份运行 PowerShell。执行策略错误时运行：<br /><code>Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser</code></Note>
       </Step>
 
-      <Step n={3} title="配置环境变量">
+      <Step n={3} title="跳过首次登录引导">
+        <p>首次运行 <code>claude</code> 会触发与 Hub 不兼容的官方登录引导。先在配置文件里写入跳过标记。</p>
+        <p>用记事本或 VS Code 打开 <code>%USERPROFILE%\.claude.json</code>（资源管理器地址栏直接粘贴此路径回车即可定位；文件不存在就新建）。写入：</p>
+        <CodeBlock code={`{
+  "hasCompletedOnboarding": true
+}`} />
+        <Note>文件已有内容时，把 <code>"hasCompletedOnboarding": true</code> 加到现有 JSON 对象中即可，不要整体覆盖。</Note>
+      </Step>
+
+      <Step n={4} title="配置环境变量">
         <p>将 <code>sk-hub-xxx</code> 替换为你的 Terminal Token，在 PowerShell 中运行：</p>
         <EnvVarsBlock shell="powershell" />
         <p className="guide-verify-label">验证：</p>
         <CodeBlock code={`[System.Environment]::GetEnvironmentVariable("ANTHROPIC_BASE_URL", "User")
-[System.Environment]::GetEnvironmentVariable("ANTHROPIC_API_KEY", "User")`} />
+[System.Environment]::GetEnvironmentVariable("ANTHROPIC_AUTH_TOKEN", "User")`} />
         <div className="guide-env-desc">
           <div className="guide-env-row"><code>ANTHROPIC_BASE_URL</code><span>Hub 代理地址，所有请求通过此地址转发</span></div>
-          <div className="guide-env-row"><code>ANTHROPIC_API_KEY</code><span>你的 Terminal Token，用于身份验证</span></div>
+          <div className="guide-env-row"><code>ANTHROPIC_AUTH_TOKEN</code><span>你的 Terminal Token，用于身份验证</span></div>
           <div className="guide-env-row"><code>CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC</code><span>禁用遥测数据上报，避免连接超时</span></div>
+          <div className="guide-env-row"><code>CLAUDE_CODE_EFFORT_LEVEL</code><span>推荐启用 max 推理强度</span></div>
         </div>
       </Step>
 
-      <Step n={4} title="验证和使用">
+      <Step n={5} title="验证和使用">
         <Note>必须<strong>重启 PowerShell</strong>（以普通用户身份）才能使环境变量生效。</Note>
         <CodeBlock code={`claude --version\nclaude`} />
         <p>在项目目录中使用：</p>
@@ -141,7 +153,16 @@ function MacosGuide() {
         <Note>遇到权限错误？使用 <code>sudo npm install -g @anthropic-ai/claude-code</code></Note>
       </Step>
 
-      <Step n={3} title="配置环境变量">
+      <Step n={3} title="跳过首次登录引导">
+        <p>首次运行 <code>claude</code> 会触发与 Hub 不兼容的官方登录引导。先在配置文件里写入跳过标记。</p>
+        <p>用编辑器打开 <code>~/.claude.json</code>（文件不存在就新建）。写入：</p>
+        <CodeBlock code={`{
+  "hasCompletedOnboarding": true
+}`} />
+        <Note>文件已有内容时，把 <code>"hasCompletedOnboarding": true</code> 加到现有 JSON 对象中即可，不要整体覆盖。</Note>
+      </Step>
+
+      <Step n={4} title="配置环境变量">
         <p>不确定用的是哪种 Shell？运行 <code>echo $SHELL</code> 查看。</p>
         <div className="guide-shell-switch">
           <button className={`guide-platform-btn ${shell === 'zsh' ? 'active' : ''}`} onClick={() => setShell('zsh')}>zsh（默认）</button>
@@ -150,15 +171,16 @@ function MacosGuide() {
         <p>将 <code>sk-hub-xxx</code> 替换为你的 Terminal Token：</p>
         <EnvVarsBlock shell={shell} />
         <p className="guide-verify-label">验证：</p>
-        <CodeBlock code={`echo $ANTHROPIC_BASE_URL\necho $ANTHROPIC_API_KEY`} />
+        <CodeBlock code={`echo $ANTHROPIC_BASE_URL\necho $ANTHROPIC_AUTH_TOKEN`} />
         <div className="guide-env-desc">
           <div className="guide-env-row"><code>ANTHROPIC_BASE_URL</code><span>Hub 代理地址，所有请求通过此地址转发</span></div>
-          <div className="guide-env-row"><code>ANTHROPIC_API_KEY</code><span>你的 Terminal Token，用于身份验证</span></div>
+          <div className="guide-env-row"><code>ANTHROPIC_AUTH_TOKEN</code><span>你的 Terminal Token，用于身份验证</span></div>
           <div className="guide-env-row"><code>CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC</code><span>禁用遥测数据上报，避免连接超时</span></div>
+          <div className="guide-env-row"><code>CLAUDE_CODE_EFFORT_LEVEL</code><span>推荐启用 max 推理强度</span></div>
         </div>
       </Step>
 
-      <Step n={4} title="验证和使用">
+      <Step n={5} title="验证和使用">
         <Note>必须<strong>重新打开 Terminal</strong> 才能使环境变量生效。</Note>
         <CodeBlock code={`claude --version\nclaude`} />
         <p>在项目目录中使用：</p>
@@ -217,7 +239,16 @@ function LinuxGuide() {
         <Note>遇到权限错误？使用 <code>sudo npm install -g @anthropic-ai/claude-code</code></Note>
       </Step>
 
-      <Step n={3} title="配置环境变量">
+      <Step n={3} title="跳过首次登录引导">
+        <p>首次运行 <code>claude</code> 会触发与 Hub 不兼容的官方登录引导。先在配置文件里写入跳过标记。</p>
+        <p>用编辑器打开 <code>~/.claude.json</code>（文件不存在就新建）。写入：</p>
+        <CodeBlock code={`{
+  "hasCompletedOnboarding": true
+}`} />
+        <Note>文件已有内容时，把 <code>"hasCompletedOnboarding": true</code> 加到现有 JSON 对象中即可，不要整体覆盖。</Note>
+      </Step>
+
+      <Step n={4} title="配置环境变量">
         <p>不确定用的是哪种 Shell？运行 <code>echo $SHELL</code> 查看。</p>
         <div className="guide-shell-switch">
           <button className={`guide-platform-btn ${shell === 'bash' ? 'active' : ''}`} onClick={() => setShell('bash')}>bash</button>
@@ -226,15 +257,16 @@ function LinuxGuide() {
         <p>将 <code>sk-hub-xxx</code> 替换为你的 Terminal Token：</p>
         <EnvVarsBlock shell={shell} />
         <p className="guide-verify-label">验证：</p>
-        <CodeBlock code={`echo $ANTHROPIC_BASE_URL\necho $ANTHROPIC_API_KEY`} />
+        <CodeBlock code={`echo $ANTHROPIC_BASE_URL\necho $ANTHROPIC_AUTH_TOKEN`} />
         <div className="guide-env-desc">
           <div className="guide-env-row"><code>ANTHROPIC_BASE_URL</code><span>Hub 代理地址，所有请求通过此地址转发</span></div>
-          <div className="guide-env-row"><code>ANTHROPIC_API_KEY</code><span>你的 Terminal Token，用于身份验证</span></div>
+          <div className="guide-env-row"><code>ANTHROPIC_AUTH_TOKEN</code><span>你的 Terminal Token，用于身份验证</span></div>
           <div className="guide-env-row"><code>CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC</code><span>禁用遥测数据上报，避免连接超时</span></div>
+          <div className="guide-env-row"><code>CLAUDE_CODE_EFFORT_LEVEL</code><span>推荐启用 max 推理强度</span></div>
         </div>
       </Step>
 
-      <Step n={4} title="验证和使用">
+      <Step n={5} title="验证和使用">
         <Note>必须<strong>重新打开终端</strong>（或运行 <code>source ~/.bashrc</code>）才能使环境变量生效。</Note>
         <CodeBlock code={`claude --version\nclaude`} />
         <p>在项目目录中使用：</p>

--- a/src/admin/frontend/src/components/GuideTab.jsx
+++ b/src/admin/frontend/src/components/GuideTab.jsx
@@ -82,12 +82,16 @@ function WindowsGuide() {
       </Step>
 
       <Step n={3} title="跳过首次登录引导">
-        <p>首次运行 <code>claude</code> 会触发与 Hub 不兼容的官方登录引导。先在配置文件里写入跳过标记。</p>
-        <p>用记事本或 VS Code 打开 <code>%USERPROFILE%\.claude.json</code>（资源管理器地址栏直接粘贴此路径回车即可定位；文件不存在就新建）。写入：</p>
+        <p>首次运行 <code>claude</code> 会触发与 Hub 不兼容的官方登录引导。在配置文件里预先写入跳过标记可绕过。</p>
+        <p>刚装完 Claude Code 时这个文件还不存在，需要新建。Windows 默认路径：</p>
+        <CodeBlock code={`C:\\Users\\<你的用户名>\\.claude.json`} />
+        <p>不确定 <code>{'<你的用户名>'}</code> 是什么？在 PowerShell 中运行：</p>
+        <CodeBlock code="echo $env:USERPROFILE" />
+        <p>输出（如 <code>C:\Users\xychen</code>）就是你的主目录，在这里新建 <code>.claude.json</code> 文件，写入：</p>
         <CodeBlock code={`{
   "hasCompletedOnboarding": true
 }`} />
-        <Note>文件已有内容时，把 <code>"hasCompletedOnboarding": true</code> 加到现有 JSON 对象中即可，不要整体覆盖。</Note>
+        <Note>如果你已经跑过一次 <code>claude</code>，文件可能已经存在 —— 这种情况把 <code>"hasCompletedOnboarding": true</code> 加到现有 JSON 对象中即可，不要整体覆盖。</Note>
       </Step>
 
       <Step n={4} title="配置环境变量">
@@ -99,7 +103,7 @@ function WindowsGuide() {
         <div className="guide-env-desc">
           <div className="guide-env-row"><code>ANTHROPIC_BASE_URL</code><span>Hub 代理地址，所有请求通过此地址转发</span></div>
           <div className="guide-env-row"><code>ANTHROPIC_AUTH_TOKEN</code><span>你的 Terminal Token，用于身份验证</span></div>
-          <div className="guide-env-row"><code>CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC</code><span>禁用遥测数据上报，避免连接超时</span></div>
+          <div className="guide-env-row"><code>CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC</code><span>禁用 claude code 上报遥测数据</span></div>
           <div className="guide-env-row"><code>CLAUDE_CODE_EFFORT_LEVEL</code><span>推荐启用 max 推理强度</span></div>
         </div>
       </Step>
@@ -154,12 +158,14 @@ function MacosGuide() {
       </Step>
 
       <Step n={3} title="跳过首次登录引导">
-        <p>首次运行 <code>claude</code> 会触发与 Hub 不兼容的官方登录引导。先在配置文件里写入跳过标记。</p>
-        <p>用编辑器打开 <code>~/.claude.json</code>（文件不存在就新建）。写入：</p>
+        <p>首次运行 <code>claude</code> 会触发与 Hub 不兼容的官方登录引导。在配置文件里预先写入跳过标记可绕过。</p>
+        <p>刚装完 Claude Code 时 <code>~/.claude.json</code> 还不存在，需要新建。不确定主目录路径？在终端中运行：</p>
+        <CodeBlock code="echo $HOME" />
+        <p>输出就是你的主目录，在这里新建 <code>.claude.json</code> 文件，写入：</p>
         <CodeBlock code={`{
   "hasCompletedOnboarding": true
 }`} />
-        <Note>文件已有内容时，把 <code>"hasCompletedOnboarding": true</code> 加到现有 JSON 对象中即可，不要整体覆盖。</Note>
+        <Note>如果你已经跑过一次 <code>claude</code>，文件可能已经存在 —— 这种情况把 <code>"hasCompletedOnboarding": true</code> 加到现有 JSON 对象中即可，不要整体覆盖。</Note>
       </Step>
 
       <Step n={4} title="配置环境变量">
@@ -175,7 +181,7 @@ function MacosGuide() {
         <div className="guide-env-desc">
           <div className="guide-env-row"><code>ANTHROPIC_BASE_URL</code><span>Hub 代理地址，所有请求通过此地址转发</span></div>
           <div className="guide-env-row"><code>ANTHROPIC_AUTH_TOKEN</code><span>你的 Terminal Token，用于身份验证</span></div>
-          <div className="guide-env-row"><code>CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC</code><span>禁用遥测数据上报，避免连接超时</span></div>
+          <div className="guide-env-row"><code>CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC</code><span>禁用 claude code 上报遥测数据</span></div>
           <div className="guide-env-row"><code>CLAUDE_CODE_EFFORT_LEVEL</code><span>推荐启用 max 推理强度</span></div>
         </div>
       </Step>
@@ -240,12 +246,14 @@ function LinuxGuide() {
       </Step>
 
       <Step n={3} title="跳过首次登录引导">
-        <p>首次运行 <code>claude</code> 会触发与 Hub 不兼容的官方登录引导。先在配置文件里写入跳过标记。</p>
-        <p>用编辑器打开 <code>~/.claude.json</code>（文件不存在就新建）。写入：</p>
+        <p>首次运行 <code>claude</code> 会触发与 Hub 不兼容的官方登录引导。在配置文件里预先写入跳过标记可绕过。</p>
+        <p>刚装完 Claude Code 时 <code>~/.claude.json</code> 还不存在，需要新建。不确定主目录路径？在终端中运行：</p>
+        <CodeBlock code="echo $HOME" />
+        <p>输出就是你的主目录，在这里新建 <code>.claude.json</code> 文件，写入：</p>
         <CodeBlock code={`{
   "hasCompletedOnboarding": true
 }`} />
-        <Note>文件已有内容时，把 <code>"hasCompletedOnboarding": true</code> 加到现有 JSON 对象中即可，不要整体覆盖。</Note>
+        <Note>如果你已经跑过一次 <code>claude</code>，文件可能已经存在 —— 这种情况把 <code>"hasCompletedOnboarding": true</code> 加到现有 JSON 对象中即可，不要整体覆盖。</Note>
       </Step>
 
       <Step n={4} title="配置环境变量">
@@ -261,7 +269,7 @@ function LinuxGuide() {
         <div className="guide-env-desc">
           <div className="guide-env-row"><code>ANTHROPIC_BASE_URL</code><span>Hub 代理地址，所有请求通过此地址转发</span></div>
           <div className="guide-env-row"><code>ANTHROPIC_AUTH_TOKEN</code><span>你的 Terminal Token，用于身份验证</span></div>
-          <div className="guide-env-row"><code>CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC</code><span>禁用遥测数据上报，避免连接超时</span></div>
+          <div className="guide-env-row"><code>CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC</code><span>禁用 claude code 上报遥测数据</span></div>
           <div className="guide-env-row"><code>CLAUDE_CODE_EFFORT_LEVEL</code><span>推荐启用 max 推理强度</span></div>
         </div>
       </Step>


### PR DESCRIPTION
## Summary

Closes #57.

- 环境变量 `ANTHROPIC_API_KEY` → `ANTHROPIC_AUTH_TOKEN`（GuideTab 8 处 + README 2 处）
- 新增 `export CLAUDE_CODE_EFFORT_LEVEL=max` 到三平台安装命令 + env 描述表（标签：推荐启用 max 推理强度）
- **新增 Step 3「跳过首次登录引导」**（在装 Claude Code 之后、配 env 之前）：让用户在 `~/.claude.json`（Windows: `C:\Users\<你的用户名>\.claude.json`）写入 `"hasCompletedOnboarding": true`，避免首次跑 `claude` 触发与 Hub 不兼容的官方登录引导
- 反映"刚装完文件不存在"的真实情况，给 `echo $env:USERPROFILE` / `echo $HOME` 帮用户定位主目录
- 微调 `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` 描述为「禁用 claude code 上报遥测数据」
- Step 顺序：① 装 Node ② 装 Claude Code ③ 跳过首次登录引导（新）④ 配 env ⑤ 验证使用

## Test plan

- [x] `npm run build --prefix src/admin/frontend` 通过
- [x] `npm run lint --prefix src/admin/frontend` 无 GuideTab 相关错误（22 条预存 lint 在 UsageTab，与本 PR 无关）
- [ ] 本地 `npm run dev` 三平台 tab 切换 review 视觉与文案
- [ ] 按 guide 在一台干净 Windows 机器走完整流程：能跳过 onboarding，跑通第一次请求
- [ ] 按 guide 在一台干净 macOS / Linux 机器走完整流程：同上

## Out of scope

- 注册截图（依赖 #58 营销首页落地后补）
- 充值流程截图（依赖 #56，仍 0 进度）
- 运行时 FAQ（401 / 余额不足 / 429 limit）—— 本 PR 不含，可后续补

🤖 Generated with [Claude Code](https://claude.com/claude-code)