### PR TITLE
fix(admin): serialize accounts.json writes to prevent OAuth refresh_token loss

### DIFF
--- a/src/admin/accounts-mutex.js
+++ b/src/admin/accounts-mutex.js
@@ -1,0 +1,31 @@
+/**
+ * Serialises read-modify-write operations on accounts.json across
+ * admin's concurrent async writers (HTTP handlers + timers + proxy event
+ * endpoints). Without this, two handlers can both readAccounts() against
+ * the same on-disk snapshot, then both writeAccounts() — losing one of
+ * the updates. Issue #62 documents the OAuth refresh_token loss case.
+ *
+ * Style mirrors src/proxy/rate-queue.js: a single Promise chain that
+ * absorbs failures so the queue keeps running, while still propagating
+ * errors back to the original caller.
+ */
+export class AccountsMutex {
+  #chain = Promise.resolve();
+
+  /**
+   * Run fn() while holding the mutex. Other callers wait until fn() resolves
+   * (or rejects). Returns whatever fn() resolves to; rejects with whatever
+   * fn() throws.
+   * @template T
+   * @param {() => Promise<T> | T} fn
+   * @returns {Promise<T>}
+   */
+  runExclusive(fn) {
+    const next = this.#chain.then(fn);
+    this.#chain = next.catch(() => {});
+    return next;
+  }
+}
+
+/** Single mutex instance shared across all admin write paths. */
+export const accountsMutex = new AccountsMutex();

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -13,6 +13,7 @@ import { isAccountCooling, reassignCoolingTerminals } from './reassignment.js';
 import { isOAuthRevoked } from '../proxy/permission-guard.js';
 import { syncRelayHealth, listRelayModels, RELAY_HEALTH_POLL_MS } from './relay-health.js';
 import { calcVirtualRateLimit } from './virtual-ratelimit.js';
+import { accountsMutex } from './accounts-mutex.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const LOGS_DIR = join(dirname(dirname(__dirname)), 'logs');
@@ -25,6 +26,16 @@ app.use(express.json());
 // In-memory relay health cache. Written by the backend poll timer and by
 // syncRateLimit(); read by sanitiseAccount() to merge health into API responses.
 const relayHealthCache = new Map(); // accountId → { status, latencyMs, model, error }
+
+// Wraps a route handler so its accounts.json read-modify-write block is
+// serialised against all other admin write paths via accountsMutex. See
+// issue #62: without this, the 60s probeAllRelays timer races with
+// /_internal/report-credentials and can overwrite a freshly rotated
+// OAuth refresh_token with a stale snapshot, permanently bricking the
+// account once the upstream rotation makes the old token invalid.
+function lockWrites(handler) {
+  return (req, res) => accountsMutex.runExclusive(() => handler(req, res));
+}
 
 // Serve React frontend static files (unauthenticated — SPA shell)
 app.use(express.static(DIST_DIR));
@@ -47,7 +58,7 @@ app.get('/api/accounts', async (_req, res) => {
   res.json(accounts.map(sanitiseAccount));
 });
 
-app.post('/api/accounts/:id/refresh-token', requireAdmin, async (req, res) => {
+app.post('/api/accounts/:id/refresh-token', requireAdmin, lockWrites(async (req, res) => {
   const accounts = await configStore.readAccounts();
   const acc = accounts.find(a => a.id === req.params.id);
   if (!acc) return res.status(404).json({ error: 'not_found' });
@@ -69,9 +80,9 @@ app.post('/api/accounts/:id/refresh-token', requireAdmin, async (req, res) => {
   } catch (err) {
     res.status(502).json({ error: err.message });
   }
-});
+}));
 
-app.post('/api/accounts/:id/sync-usage', requireAdmin, async (req, res) => {
+app.post('/api/accounts/:id/sync-usage', requireAdmin, lockWrites(async (req, res) => {
   const accounts = await configStore.readAccounts();
   const acc = accounts.find(a => a.id === req.params.id);
   if (!acc) return res.status(404).json({ error: 'not_found' });
@@ -89,9 +100,9 @@ app.post('/api/accounts/:id/sync-usage', requireAdmin, async (req, res) => {
   } catch (err) {
     res.status(502).json({ error: err.message });
   }
-});
+}));
 
-app.patch('/api/accounts/:id', requireAdmin, async (req, res) => {
+app.patch('/api/accounts/:id', requireAdmin, lockWrites(async (req, res) => {
   const accounts = await configStore.readAccounts();
   const acc = accounts.find(a => a.id === req.params.id);
   if (!acc) return res.status(404).json({ error: 'not_found' });
@@ -146,7 +157,7 @@ app.patch('/api/accounts/:id', requireAdmin, async (req, res) => {
     await reassignCoolingTerminals(acc.id, accounts, null, configStore);
   }
   res.json(sanitiseAccount(acc));
-});
+}));
 
 // List available claude models from a relay station's /v1/models endpoint.
 app.get('/api/accounts/:id/models', requireAdmin, async (req, res) => {
@@ -162,7 +173,7 @@ app.get('/api/accounts/:id/models', requireAdmin, async (req, res) => {
   }
 });
 
-app.post('/api/accounts/:id/force-online', requireAdmin, async (req, res) => {
+app.post('/api/accounts/:id/force-online', requireAdmin, lockWrites(async (req, res) => {
   const accounts = await configStore.readAccounts();
   const acc = accounts.find(a => a.id === req.params.id);
   if (!acc) return res.status(404).json({ error: 'not_found' });
@@ -170,9 +181,9 @@ app.post('/api/accounts/:id/force-online', requireAdmin, async (req, res) => {
   acc.cooldownUntil = null;
   await configStore.writeAccounts(accounts);
   res.json(sanitiseAccount(acc));
-});
+}));
 
-app.post('/api/accounts/:id/force-offline', requireAdmin, async (req, res) => {
+app.post('/api/accounts/:id/force-offline', requireAdmin, lockWrites(async (req, res) => {
   const accounts = await configStore.readAccounts();
   const acc = accounts.find(a => a.id === req.params.id);
   if (!acc) return res.status(404).json({ error: 'not_found' });
@@ -181,22 +192,22 @@ app.post('/api/accounts/:id/force-offline', requireAdmin, async (req, res) => {
   // Force-offline: reassign all terminals (auto + manual) away from the dead account
   await reassignTerminals(req.params.id, accounts.filter(a => a.id !== req.params.id), null);
   res.json(sanitiseAccount(acc));
-});
+}));
 
-app.delete('/api/accounts/:id', requireAdmin, async (req, res) => {
+app.delete('/api/accounts/:id', requireAdmin, lockWrites(async (req, res) => {
   let accounts = await configStore.readAccounts();
   const remaining = accounts.filter(a => a.id !== req.params.id);
   // Delete: reassign ALL terminals (both auto and manual)
   await reassignTerminals(req.params.id, remaining, null);
   await configStore.writeAccounts(remaining);
   res.json({ ok: true });
-});
+}));
 
 // Add a third-party relay-station account (static apiKey + baseUrl).
 // Relays serve Claude /v1/messages without OAuth; they're used as a fallback
 // tier when all OAuth accounts are cooling/exhausted. Optional per-tier
 // modelMap rewrites body.model before forwarding (e.g. opus-4-7 → opus-4-6).
-app.post('/api/accounts/relay', requireAdmin, async (req, res) => {
+app.post('/api/accounts/relay', requireAdmin, lockWrites(async (req, res) => {
   const { nickname, baseUrl, apiKey, modelMap } = req.body ?? {};
   if (typeof nickname !== 'string' || nickname.trim().length === 0) {
     return res.status(400).json({ error: 'nickname_required' });
@@ -228,11 +239,11 @@ app.post('/api/accounts/relay', requireAdmin, async (req, res) => {
   accounts.push(acc);
   await configStore.writeAccounts(accounts);
   res.status(201).json(sanitiseAccount(acc));
-});
+}));
 
 // Add an aggregated routing card — multiple upstream providers behind a single
 // token, with per-tier routing (Opus/Sonnet/Haiku/Image → provider + model).
-app.post('/api/accounts/aggregated', requireAdmin, async (req, res) => {
+app.post('/api/accounts/aggregated', requireAdmin, lockWrites(async (req, res) => {
   const { nickname, providers, routing, plan } = req.body ?? {};
   if (typeof nickname !== 'string' || nickname.trim().length === 0) {
     return res.status(400).json({ error: 'nickname_required' });
@@ -286,7 +297,7 @@ app.post('/api/accounts/aggregated', requireAdmin, async (req, res) => {
   accounts.push(acc);
   await configStore.writeAccounts(accounts);
   res.status(201).json(sanitiseAccount(acc));
-});
+}));
 
 // ── Terminals ────────────────────────────────────────────────────────────
 
@@ -425,7 +436,7 @@ app.post('/api/oauth/submit-code/:sessionId', requireAdmin, async (req, res) => 
 });
 
 // Step 3: poll until credentials file appears, then import
-app.post('/api/oauth/import/:sessionId', requireAdmin, async (req, res) => {
+app.post('/api/oauth/import/:sessionId', requireAdmin, lockWrites(async (req, res) => {
   const session = oauthSessions.get(req.params.sessionId);
   if (!session) return res.status(404).json({ error: 'session_not_found' });
 
@@ -441,7 +452,7 @@ app.post('/api/oauth/import/:sessionId', requireAdmin, async (req, res) => {
     // Keep session in map so the client can retry or diagnose
     res.status(400).json({ error: err.message });
   }
-});
+}));
 
 // Fallback: manual terminal flow
 app.post('/api/oauth/start-manual', requireAdmin, (_req, res) => {
@@ -450,7 +461,7 @@ app.post('/api/oauth/start-manual', requireAdmin, (_req, res) => {
   res.json({ sessionId, loginCmd });
 });
 
-app.post('/api/oauth/import-manual/:sessionId', requireAdmin, async (req, res) => {
+app.post('/api/oauth/import-manual/:sessionId', requireAdmin, lockWrites(async (req, res) => {
   const session = oauthSessions.get(req.params.sessionId);
   if (!session) return res.status(404).json({ error: 'session_not_found' });
   oauthSessions.delete(req.params.sessionId);
@@ -463,7 +474,7 @@ app.post('/api/oauth/import-manual/:sessionId', requireAdmin, async (req, res) =
   } catch (err) {
     res.status(400).json({ error: err.message });
   }
-});
+}));
 
 // ── Helpers ───────────────────────────────────────────────────────────────
 
@@ -676,7 +687,7 @@ async function reassignTerminals(removedAccountId, availableAccounts, modes) {
 // ─────────────────────────────────────────────────────────────────────────
 
 // Probe all accounts on demand (called by frontend adaptive polling)
-app.post('/api/sync-usage-all', requireAdmin, async (_req, res) => {
+app.post('/api/sync-usage-all', requireAdmin, lockWrites(async (_req, res) => {
   try {
     const accounts = await configStore.readAccounts();
     for (const acc of accounts) {
@@ -693,7 +704,7 @@ app.post('/api/sync-usage-all', requireAdmin, async (_req, res) => {
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
-});
+}));
 
 // ── Internal API (called by proxy, no auth) ──────────────────────────────
 
@@ -713,7 +724,7 @@ async function syncProxyTerminals() {
 
 // Called by proxy when it detects a 403 permission_error (OAuth revoked)
 // or the circuit breaker opens for an account (issue #42).
-app.post('/_internal/report-exhausted', async (req, res) => {
+app.post('/_internal/report-exhausted', lockWrites(async (req, res) => {
   try {
     const { accountId } = req.body;
     const accounts = await configStore.readAccounts();
@@ -729,7 +740,7 @@ app.post('/_internal/report-exhausted', async (req, res) => {
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
-});
+}));
 
 // Called by proxy on 429/529 fallback — terminal.accountId changed in memory.
 app.post('/_internal/report-fallback', async (req, res) => {
@@ -748,7 +759,7 @@ app.post('/_internal/report-fallback', async (req, res) => {
 });
 
 // Called by proxy after OAuth token refresh — admin patches credentials only.
-app.post('/_internal/report-credentials', async (req, res) => {
+app.post('/_internal/report-credentials', lockWrites(async (req, res) => {
   try {
     const { accountId, credentials } = req.body;
     const accounts = await configStore.readAccounts();
@@ -760,7 +771,7 @@ app.post('/_internal/report-credentials', async (req, res) => {
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
-});
+}));
 
 // ── Public routes ────────────────────────────────────────────────────────
 
@@ -782,37 +793,39 @@ setInterval(syncProxyTerminals, 30_000).unref();
 // all relay accounts that have a probe model configured and updates the
 // relayHealthCache. Frontend just reads the cache via getAccounts.
 async function probeAllRelays() {
-  try {
-    const accounts = await configStore.readAccounts();
-    let dirty = false;
-    for (const acc of accounts) {
-      if (acc.type !== 'relay' && acc.type !== 'aggregated') continue;
-      if (acc.status === 'exhausted') continue;
-      if (acc.type === 'aggregated') {
-        acc.rateLimit = await calcVirtualRateLimit(acc.id, acc.plan ?? 'max', LOGS_DIR);
-        await probeAndCacheRelay(acc); // 同时探测 provider 健康
-        dirty = true;
-      } else {
-        await probeAndCacheRelay(acc);
-        dirty = true;
+  await accountsMutex.runExclusive(async () => {
+    try {
+      const accounts = await configStore.readAccounts();
+      let dirty = false;
+      for (const acc of accounts) {
+        if (acc.type !== 'relay' && acc.type !== 'aggregated') continue;
+        if (acc.status === 'exhausted') continue;
+        if (acc.type === 'aggregated') {
+          acc.rateLimit = await calcVirtualRateLimit(acc.id, acc.plan ?? 'max', LOGS_DIR);
+          await probeAndCacheRelay(acc); // 同时探测 provider 健康
+          dirty = true;
+        } else {
+          await probeAndCacheRelay(acc);
+          dirty = true;
+        }
       }
-    }
-    if (dirty) {
-      await configStore.writeAccounts(accounts);
-    }
-    // 安全网：每轮无条件检查所有 cooling/exhausted 账号，把挂载在上面的
-    // 终端迁走（含 manual）。不能只在"刚进入 cooling"的瞬间触发，否则
-    //   - 重启后从磁盘读到的账号本就是 cooling，永远跳过
-    //   - 用户事后手动挂载到 cooling 账号上，永远跳过
-    // reassignCoolingTerminals 在没有匹配终端或没有温账号时是 no-op，多次调用安全。
-    for (const acc of accounts) {
-      if (acc.status === 'exhausted' || isAccountCooling(acc)) {
-        await reassignCoolingTerminals(acc.id, accounts, null, configStore);
+      if (dirty) {
+        await configStore.writeAccounts(accounts);
       }
+      // 安全网：每轮无条件检查所有 cooling/exhausted 账号，把挂载在上面的
+      // 终端迁走（含 manual）。不能只在"刚进入 cooling"的瞬间触发，否则
+      //   - 重启后从磁盘读到的账号本就是 cooling，永远跳过
+      //   - 用户事后手动挂载到 cooling 账号上，永远跳过
+      // reassignCoolingTerminals 在没有匹配终端或没有温账号时是 no-op，多次调用安全。
+      for (const acc of accounts) {
+        if (acc.status === 'exhausted' || isAccountCooling(acc)) {
+          await reassignCoolingTerminals(acc.id, accounts, null, configStore);
+        }
+      }
+    } catch (err) {
+      console.error('[relay-poll] error:', err.message);
     }
-  } catch (err) {
-    console.error('[relay-poll] error:', err.message);
-  }
+  });
 }
 probeAllRelays(); // Initial probe on startup — don't wait 60s
 setInterval(probeAllRelays, RELAY_HEALTH_POLL_MS);

--- a/tests/accounts-mutex.test.js
+++ b/tests/accounts-mutex.test.js
@@ -1,0 +1,135 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { createConfigStore } from '../src/shared/config.js';
+import { AccountsMutex } from '../src/admin/accounts-mutex.js';
+
+let dir;
+test.before(async () => { dir = await mkdtemp(join(tmpdir(), 'hub-mutex-')); });
+test.after(async () => { await rm(dir, { recursive: true }); });
+
+// ── Baseline: demonstrate the race exists when read-modify-write is unwrapped ──
+// This is the bug pattern from issue #62: probeAllRelays-style operation with a
+// long internal await (network probe) reads an old snapshot, then a concurrent
+// report-credentials operation writes a new credential, then probeAllRelays
+// completes and overwrites with its stale snapshot — losing the credential update.
+test('baseline · concurrent read-modify-write loses updates without mutex', async () => {
+  const store = createConfigStore(dir);
+  await store.writeAccounts([
+    { id: 'a', credentials: { refreshToken: 'RT_v0' } },
+    { id: 'b', rateLimit: null },
+  ]);
+
+  // Op A: probeAllRelays-like — reads, awaits (simulating relay probe), writes
+  const opA = (async () => {
+    const accounts = await store.readAccounts();
+    await new Promise(r => setTimeout(r, 30)); // simulate network probe
+    accounts.find(a => a.id === 'b').rateLimit = { utilization: 0.5 };
+    await store.writeAccounts(accounts);
+  })();
+
+  // Op B: report-credentials-like — reads after A's read, patches credential, writes
+  await new Promise(r => setTimeout(r, 5));
+  const opB = (async () => {
+    const accounts = await store.readAccounts();
+    accounts.find(a => a.id === 'a').credentials.refreshToken = 'RT_v1';
+    await store.writeAccounts(accounts);
+  })();
+
+  await Promise.all([opA, opB]);
+
+  const final = await store.readAccounts();
+  assert.equal(
+    final.find(a => a.id === 'a').credentials.refreshToken,
+    'RT_v0',
+    'unwrapped race: B\'s RT_v1 update is overwritten by A\'s stale snapshot',
+  );
+});
+
+// ── Fix: AccountsMutex serialises read-modify-write so updates are not lost ──
+test('fix · AccountsMutex serialises operations, both updates preserved', async () => {
+  const store = createConfigStore(dir);
+  await store.writeAccounts([
+    { id: 'a', credentials: { refreshToken: 'RT_v0' } },
+    { id: 'b', rateLimit: null },
+  ]);
+
+  const mutex = new AccountsMutex();
+
+  // Same race scenario but each op is wrapped in mutex.runExclusive
+  const opA = mutex.runExclusive(async () => {
+    const accounts = await store.readAccounts();
+    await new Promise(r => setTimeout(r, 30));
+    accounts.find(a => a.id === 'b').rateLimit = { utilization: 0.5 };
+    await store.writeAccounts(accounts);
+  });
+
+  await new Promise(r => setTimeout(r, 5));
+  const opB = mutex.runExclusive(async () => {
+    const accounts = await store.readAccounts();
+    accounts.find(a => a.id === 'a').credentials.refreshToken = 'RT_v1';
+    await store.writeAccounts(accounts);
+  });
+
+  await Promise.all([opA, opB]);
+
+  const final = await store.readAccounts();
+  assert.equal(
+    final.find(a => a.id === 'a').credentials.refreshToken,
+    'RT_v1',
+    'with mutex: B reads after A completes, RT_v1 persists',
+  );
+  assert.deepEqual(
+    final.find(a => a.id === 'b').rateLimit,
+    { utilization: 0.5 },
+    'with mutex: A\'s rateLimit update also preserved',
+  );
+});
+
+// ── runExclusive returns the function's resolved value ──
+test('runExclusive returns the value resolved by fn', async () => {
+  const mutex = new AccountsMutex();
+  const result = await mutex.runExclusive(async () => 42);
+  assert.equal(result, 42);
+});
+
+// ── runExclusive propagates errors from fn to its caller ──
+test('runExclusive rejects when fn throws, chain stays usable', async () => {
+  const mutex = new AccountsMutex();
+
+  await assert.rejects(
+    () => mutex.runExclusive(async () => { throw new Error('boom'); }),
+    /boom/,
+  );
+
+  // Chain must remain usable after a rejection
+  const result = await mutex.runExclusive(async () => 'still works');
+  assert.equal(result, 'still works');
+});
+
+// ── Strict serialisation order: 3 concurrent runs execute sequentially ──
+test('runExclusive enforces FIFO order across concurrent runners', async () => {
+  const mutex = new AccountsMutex();
+  const order = [];
+  const results = await Promise.all([
+    mutex.runExclusive(async () => {
+      await new Promise(r => setTimeout(r, 20));
+      order.push(1);
+      return 1;
+    }),
+    mutex.runExclusive(async () => {
+      await new Promise(r => setTimeout(r, 5));
+      order.push(2);
+      return 2;
+    }),
+    mutex.runExclusive(async () => {
+      order.push(3);
+      return 3;
+    }),
+  ]);
+  assert.deepEqual(order, [1, 2, 3], 'execution order must follow enqueue order');
+  assert.deepEqual(results, [1, 2, 3]);
+});


### PR DESCRIPTION
## Summary

- 引入 `AccountsMutex`（promise-chain 风格，对齐 `src/proxy/rate-queue.js`）作为 admin 进程内 accounts.json 的写盘 critical section
- 14 处 \`configStore.writeAccounts\` 调用点全部经 \`lockWrites\` 包装器或直接 \`accountsMutex.runExclusive\` 保护
- 5 个新 test 覆盖：基线 race 复现、mutex 修复后无 race、return value 透传、错误传播、FIFO 串行序

Closes #62

## Test plan

- [x] \`npm test\` 全 210 用例通过（含 5 个新 mutex 用例）
- [x] \`node -c src/admin/index.js\` 语法验证通过
- [x] 基线 race 测试 (\`tests/accounts-mutex.test.js\` 第 1 个 test) 在不加 mutex 时确认 \`RT_v1\` 被覆盖回 \`RT_v0\`，证明 race 真实存在
- [x] mutex 测试 (第 2 个) 加 mutex 后 \`RT_v1\` 与 \`rateLimit\` 都保留，证明修法有效
- [ ] 部署到 ECS 后用同一 OAuth 账号连续跑 24h，proactive refresh log 不应再出现 \`Refresh token not found or invalid\`（issue #62 DoD）
- [ ] 用户在 sprint review 接受

## 工程注意

- **mutex 内含网络调用**：本仓库规模（单 admin 进程，少量用户），contention 影响可忽略；选简单正确的 \"wrap all\" 模式而非 \"compute outside, commit inside\" 二阶段重构
- **写不影响读**：\`/api/accounts\` GET 和其他只读路径不进 mutex —— configStore.readAccounts 单次原子 read，atomic write 保证 reader 看到完整旧/新数据
- **terminals.json 写盘不受影响**：terminals.json 走独立路径（\`writeTerminals\`），不加 mutex（issue scope 仅覆盖 accounts.json race）

## Out of Scope（issue body 已声明，单独 issue 跟）

- 熔断器 \`onOpen\` 未接 \`markUnauthorized\`（CLAUDE.md 描述与代码不一致）
- proactive refresh 失败静默吞错
- 账号 OAuth observability 字段

🤖 Generated with [Claude Code](https://claude.com/claude-code)