### PR TITLE
fix(proxy): preserve in-memory OAuth credentials when memory is fresher than disk

### DIFF
--- a/src/proxy/account-pool.js
+++ b/src/proxy/account-pool.js
@@ -320,59 +320,78 @@ export class AccountPool {
     return this.#rateQueues.get(accountId);
   }
 
-  #startWatch() {
-    // Merge helper: sync credentials and account list from disk without overwriting
-    // in-memory rate-limit state (which is fresher from actual API response headers).
-    const mergeFromDisk = async () => {
-      try {
-        const fresh = await this.#configStore.readAccounts();
-        for (const freshAcc of fresh) {
-          const mem = this.#accounts.find(a => a.id === freshAcc.id);
-          if (mem) {
-            // OAuth: in-memory rateLimit/cooldown 来自 Anthropic 响应头，比磁盘新；
-            //   admin 探测虽偶尔更新磁盘，但仍可能落后于实时响应头。
-            // Aggregated/Relay: rateLimit 是 admin 端虚拟计算/探测的产物，proxy
-            //   自己从来不更新它（不接收上游限额头）。此时磁盘永远是"权威源"，
-            //   保留内存反而会丢弃 admin 的最新计算（如 5h 边界过后的归零）。
-            const isRelayLike = mem.type === 'relay' || mem.type === 'aggregated';
-            const preservedRateLimit = isRelayLike ? null : mem.rateLimit;
-            const preservedCooldown = isRelayLike ? null : mem.cooldownUntil;
-            const preservedHealth = mem.health;
-            const preservedProviderHealths = mem.type === 'aggregated' && Array.isArray(mem.providers)
-              ? mem.providers.map(p => p.health)
-              : [];
+  /**
+   * Sync accounts from disk to in-memory pool. Called by fs.watch (when admin
+   * writes accounts.json) and by 15s polling fallback. Public so tests can
+   * exercise the merge logic directly without spinning up watchers/timers.
+   *
+   * Field ownership rules (whose state is fresher: memory vs disk):
+   * - rateLimit / cooldownUntil (OAuth): memory wins — populated from live
+   *   Anthropic response headers, admin's periodic probe lags behind.
+   * - rateLimit (relay/aggregated): disk wins — proxy never updates these
+   *   (no upstream limit headers); admin's virtual calc/probe is authoritative.
+   * - health / provider health: memory wins — set by proxy probes.
+   * - credentials (OAuth): whoever has the higher expiresAt wins. proxy's
+   *   ensureFreshToken mutates in-memory before fire-and-forget reporting to
+   *   admin, so memory is briefly newer than disk between refresh and admin's
+   *   write. Rolling memory back to disk during that window invalidates the
+   *   rotated refresh_token at Anthropic and locks the account out (issue #65).
+   * - credentials (relay/aggregated): disk wins — static apiKey, admin sole
+   *   writer; no expiresAt means the comparison naturally selects disk.
+   */
+  async mergeFromDisk() {
+    try {
+      const fresh = await this.#configStore.readAccounts();
+      for (const freshAcc of fresh) {
+        const mem = this.#accounts.find(a => a.id === freshAcc.id);
+        if (mem) {
+          const isRelayLike = mem.type === 'relay' || mem.type === 'aggregated';
+          const preservedRateLimit = isRelayLike ? null : mem.rateLimit;
+          const preservedCooldown = isRelayLike ? null : mem.cooldownUntil;
+          const preservedHealth = mem.health;
+          const preservedProviderHealths = mem.type === 'aggregated' && Array.isArray(mem.providers)
+            ? mem.providers.map(p => p.health)
+            : [];
 
-            // Full replace from disk
-            Object.assign(mem, freshAcc);
+          // Issue #65: only roll memory.credentials back to disk if disk's
+          // expiresAt is at least as fresh as memory's. Equal/missing on both
+          // sides (relay/aggregated) → disk wins, matching the prior behavior.
+          const memExpiry = mem.credentials?.expiresAt ?? 0;
+          const diskExpiry = freshAcc.credentials?.expiresAt ?? 0;
+          const preservedCredentials = memExpiry > diskExpiry ? mem.credentials : null;
 
-            // Restore preserved state — OAuth only
-            if (preservedRateLimit !== null) mem.rateLimit = preservedRateLimit;
-            if (preservedCooldown !== null) mem.cooldownUntil = preservedCooldown;
-            mem.health = preservedHealth;
-            if (Array.isArray(mem.providers) && preservedProviderHealths.length) {
-              for (let i = 0; i < Math.min(mem.providers.length, preservedProviderHealths.length); i++) {
-                mem.providers[i].health = preservedProviderHealths[i];
-              }
+          // Full replace from disk
+          Object.assign(mem, freshAcc);
+
+          // Restore preserved state
+          if (preservedCredentials) mem.credentials = preservedCredentials;
+          if (preservedRateLimit !== null) mem.rateLimit = preservedRateLimit;
+          if (preservedCooldown !== null) mem.cooldownUntil = preservedCooldown;
+          mem.health = preservedHealth;
+          if (Array.isArray(mem.providers) && preservedProviderHealths.length) {
+            for (let i = 0; i < Math.min(mem.providers.length, preservedProviderHealths.length); i++) {
+              mem.providers[i].health = preservedProviderHealths[i];
             }
           }
         }
-        // Add/remove accounts that were added/deleted via admin
-        const freshIds = new Set(fresh.map(a => a.id));
-        const memIds = new Set(this.#accounts.map(a => a.id));
-        for (const a of fresh) if (!memIds.has(a.id)) this.#accounts.push(a);
-        this.#accounts = this.#accounts.filter(a => freshIds.has(a.id));
-      } catch { /* ignore */ }
-    };
+      }
+      // Add/remove accounts that were added/deleted via admin
+      const freshIds = new Set(fresh.map(a => a.id));
+      const memIds = new Set(this.#accounts.map(a => a.id));
+      for (const a of fresh) if (!memIds.has(a.id)) this.#accounts.push(a);
+      this.#accounts = this.#accounts.filter(a => freshIds.has(a.id));
+    } catch { /* ignore */ }
+  }
 
+  #startWatch() {
+    const trigger = () => this.mergeFromDisk();
     try {
-      // fs.watch fires when admin writes accounts.json — merge credentials only,
-      // never do a full replace that would overwrite fresher in-memory rate-limit state.
-      this.#watcher = watch(this.#configStore.accountsPath, { persistent: false }, mergeFromDisk);
+      this.#watcher = watch(this.#configStore.accountsPath, { persistent: false }, trigger);
     } catch {
       // fs.watch not available in test environments
     }
     // Polling fallback for WSL2 where fs.watch is unreliable (inotify limitations).
-    setInterval(mergeFromDisk, 15000).unref();
+    setInterval(trigger, 15000).unref();
   }
 
   #startProactiveRefresh() {

--- a/tests/account-pool.test.js
+++ b/tests/account-pool.test.js
@@ -512,3 +512,139 @@ test('selectFallback skips cooling aggregated account', () => {
   const fb = pool.selectFallback(new Set());
   assert.equal(fb.id, 'acc_agg_warm');
 });
+
+// ── mergeFromDisk credential preservation (issue #65) ──────────────────────
+
+test('mergeFromDisk preserves in-memory OAuth credentials when memory.expiresAt > disk.expiresAt (race regression #65)', async () => {
+  // Simulate the race: proxy ensureFreshToken just refreshed → memory has NEW
+  // credentials (rotated refresh_token), but admin has not yet written to disk.
+  // mergeFromDisk reading stale disk MUST NOT roll back memory; otherwise the
+  // old refresh_token is invalidated by Anthropic and the account dies forever.
+  const memCreds = {
+    accessToken: 'new_at',
+    refreshToken: 'new_rt',
+    expiresAt: Date.now() + 3_600_000,
+    scopes: ['user:inference'],
+  };
+  const diskCreds = {
+    accessToken: 'old_at',
+    refreshToken: 'old_rt',
+    expiresAt: Date.now() - 1_000,
+    scopes: ['user:inference'],
+  };
+  const memAcc = { ...makeAccount('acc_1'), credentials: memCreds };
+  const diskAcc = { ...makeAccount('acc_1'), credentials: diskCreds };
+
+  const pool = new AccountPool({
+    accounts: [memAcc],
+    terminals: [],
+    configStore: {
+      readAccounts: async () => [diskAcc],
+      writeAccounts: async () => {},
+    },
+  });
+
+  await pool.mergeFromDisk();
+
+  const result = pool.getAccount('acc_1');
+  assert.equal(result.credentials.accessToken, 'new_at', 'in-memory accessToken must not be rolled back to disk');
+  assert.equal(result.credentials.refreshToken, 'new_rt', 'in-memory refreshToken (rotated) must not be replaced with consumed disk value');
+  assert.equal(result.credentials.expiresAt, memCreds.expiresAt);
+});
+
+test('mergeFromDisk applies disk credentials when disk.expiresAt > memory.expiresAt (admin manual refresh)', async () => {
+  // Reverse race: admin refresh-token endpoint completed and wrote new creds
+  // to disk. Proxy memory still holds older creds. mergeFromDisk should adopt
+  // disk's newer credentials.
+  const memCreds = {
+    accessToken: 'old_at',
+    refreshToken: 'old_rt',
+    expiresAt: Date.now() - 1_000,
+    scopes: [],
+  };
+  const diskCreds = {
+    accessToken: 'new_at',
+    refreshToken: 'new_rt',
+    expiresAt: Date.now() + 3_600_000,
+    scopes: [],
+  };
+  const memAcc = { ...makeAccount('acc_1'), credentials: memCreds };
+  const diskAcc = { ...makeAccount('acc_1'), credentials: diskCreds };
+
+  const pool = new AccountPool({
+    accounts: [memAcc],
+    terminals: [],
+    configStore: {
+      readAccounts: async () => [diskAcc],
+      writeAccounts: async () => {},
+    },
+  });
+
+  await pool.mergeFromDisk();
+
+  const result = pool.getAccount('acc_1');
+  assert.equal(result.credentials.accessToken, 'new_at', 'disk credentials should be applied when disk is newer');
+  assert.equal(result.credentials.refreshToken, 'new_rt');
+  assert.equal(result.credentials.expiresAt, diskCreds.expiresAt);
+});
+
+test('mergeFromDisk is idempotent when memory and disk have equal expiresAt', async () => {
+  // Steady state: proxy reported, admin wrote, polling reads disk = memory.
+  // Multiple mergeFromDisk calls should not crash, loop, or mutate creds.
+  const sharedExp = Date.now() + 3_600_000;
+  const sharedCreds = { accessToken: 'a', refreshToken: 'b', expiresAt: sharedExp, scopes: [] };
+  const memAcc = { ...makeAccount('acc_1'), credentials: { ...sharedCreds } };
+  const diskAcc = { ...makeAccount('acc_1'), credentials: { ...sharedCreds } };
+
+  const pool = new AccountPool({
+    accounts: [memAcc],
+    terminals: [],
+    configStore: {
+      readAccounts: async () => [diskAcc],
+      writeAccounts: async () => {},
+    },
+  });
+
+  await pool.mergeFromDisk();
+  await pool.mergeFromDisk();
+  await pool.mergeFromDisk();
+
+  const result = pool.getAccount('acc_1');
+  assert.equal(result.credentials.accessToken, 'a');
+  assert.equal(result.credentials.expiresAt, sharedExp);
+});
+
+test('mergeFromDisk syncs relay credentials from disk (no expiresAt → admin authoritative)', async () => {
+  // Relay/aggregated accounts have static apiKey, no expiresAt. Admin is the
+  // sole writer of these credentials, so disk must always win — preserves
+  // existing behavior of #46 for non-OAuth account types.
+  const memRelay = {
+    id: 'relay_1',
+    email: 'relay@test',
+    plan: 'pro',
+    type: 'relay',
+    credentials: { apiKey: 'old_key', baseUrl: 'https://old.example' },
+    status: 'idle',
+    cooldownUntil: null,
+    addedAt: Date.now(),
+  };
+  const diskRelay = {
+    ...memRelay,
+    credentials: { apiKey: 'new_key', baseUrl: 'https://new.example' },
+  };
+
+  const pool = new AccountPool({
+    accounts: [memRelay],
+    terminals: [],
+    configStore: {
+      readAccounts: async () => [diskRelay],
+      writeAccounts: async () => {},
+    },
+  });
+
+  await pool.mergeFromDisk();
+
+  const result = pool.getAccount('relay_1');
+  assert.equal(result.credentials.apiKey, 'new_key', 'relay apiKey should sync from disk (admin is sole writer)');
+  assert.equal(result.credentials.baseUrl, 'https://new.example');
+});


### PR DESCRIPTION
## Summary

`mergeFromDisk` 的 `Object.assign(mem, freshAcc)` 全量复制（#46 为聚合账号 providers 同步而引入）会在每次 polling / fs.watch 时把 in-memory 的 OAuth credentials 回滚到磁盘旧快照。配合 Anthropic OAuth refresh_token rotation，回滚瞬间的旧 refresh_token 已被服务端标记 consumed，下一次 refresh 直接 `invalid_grant` —— 订阅账号永久死锁，必须删除重新 OAuth login 才能恢复。

**修法**：`memory.credentials.expiresAt > disk.credentials.expiresAt` 时 preserve memory；否则用 disk。relay/aggregated（无 expiresAt → 两边 0 fallback）维持 disk wins，与 #46 行为一致。

**重构**：把 `mergeFromDisk` 闭包提为 public method，方便测试直接调用，不依赖启动 watcher/timer。

Closes #65

## 与 #62 / PR #63 的关系

#62 修了 admin 进程内 race（`probeAllRelays` ↔ `report-credentials` 写盘互相覆盖），accountsMutex 串行化 14 处 writeAccounts —— 该 fix 仍正确且必要。

本 PR 修的是 proxy ↔ disk race，机制独立。两者一起才能彻底关掉 "OAuth refresh 永久失败" 症状。

## Test plan

- [x] `npm test` 209/209 通过（含 4 个新增测试）
- [x] Test 1 race regression：memory 有 NEW（刚 refresh 完）+ disk 有 OLD（admin 还没写） → 验证 `mergeFromDisk` 后 memory 仍是 NEW
- [x] Test 2 admin manual refresh：disk.expiresAt > memory.expiresAt → 验证 disk credentials 复制到 memory
- [x] Test 3 idempotency：相等 expiresAt 多次调用不崩、不死循环
- [x] Test 4 relay/aggregated：无 expiresAt → disk wins，apiKey 从 disk 同步（#46 行为兼容）
- [ ] Manual ECS soak（24h）：staging 部署后观察
  - 不再出 `Refresh token not found` / `invalid_grant` admin 日志
  - 订阅账号 OAuth 自动刷新成功，无需手动 / 重加
  - 用户终端不再 401/429 retry 死循环

## Risks

- 现有 226+ 测试不动，不改 admin / forwarder / token-manager 任何逻辑
- 唯一 in-flight 改动：mergeFromDisk 时 memory.credentials 多一条 expiresAt 比较（4 行），不影响 hot path（merge 走 polling/fs.watch，非每请求路径）
- 重构（闭包提 method）保持原行为，#startWatch 仅改为 `() => this.mergeFromDisk()` 触发器

## Out of scope

- proxy 上报 admin 失败（admin 不可达）的重试机制 — 单独跟踪
- 取消 `probeAllRelays` 60s 无条件写盘（不必要写也触发 fs.watch） — 优化项，本 fix 不依赖